### PR TITLE
PP 164: Add prepublish build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-contracts",
-  "version": "0.0.1",
+  "version": "0.0.2-alpha-8",
   "description": "This project contains all the contracts needed for the rif relay system.",
   "main": "dist/index.js",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-contracts",
-  "version": "0.0.2-alpha-8",
+  "version": "0.0.2-alpha-0",
   "description": "This project contains all the contracts needed for the rif relay system.",
   "main": "dist/index.js",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rsksmart/rif-relay-contracts",
+  "name": "@antomor_iovlabs/rif-relay-contracts",
   "version": "0.0.1",
   "description": "This project contains all the contracts needed for the rif relay system.",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@antomor_iovlabs/rif-relay-contracts",
+  "name": "@rsksmart/rif-relay-contracts",
   "version": "0.0.1",
   "description": "This project contains all the contracts needed for the rif relay system.",
   "main": "dist/index.js",

--- a/scripts/prepublishOnly
+++ b/scripts/prepublishOnly
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 pinst --disable
+npm run dist

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
   "exclude": [
     "dist",
     "node_modules",
-    "build"
+    "build",
+    "test"
   ]
 }


### PR DESCRIPTION
## What

- Fix the build not to include the test folder
- Add the build step in the prepublish script

## Why

- The build includes the test folder
- We need to build the library before publishing it
