### PR TITLE
PP-130-v2/remainder management

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,4 @@
+{
+    "require": "ts-node/register/transpile-only",
+    "spec": "./test/*.test.ts"
+}

--- a/contracts/Collector.sol
+++ b/contracts/Collector.sol
@@ -9,18 +9,21 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 contract Collector is ICollector{
     IERC20 public token;
     address public owner;
+    address private remainderAddress;
     RevenuePartner[] private partners;
 
     constructor(
         address _owner,
         IERC20 _token,
-        RevenuePartner[] memory _partners
+        RevenuePartner[] memory _partners,
+        address _remainderAddress
     )
     public
     validShares(_partners)
     {   
         owner = _owner;
         token = _token;
+        remainderAddress = _remainderAddress;
         for (uint i = 0; i < _partners.length; i++)
             partners.push(_partners[i]);
     }
@@ -29,18 +32,33 @@ contract Collector is ICollector{
     external
     validShares(_partners)
     onlyOwner()
-    {
-        uint balance = token.balanceOf(address(this));
-        require(balance == 0, "can't update with balance > 0");
-    
+    noBalanceToShare()
+    {    
         delete partners;
-        
+
         for (uint i = 0; i < _partners.length; i++)
             partners.push(_partners[i]);
     }
 
-    function getBalance()
+    //@notice Withdraw the actual remainder and then update the remainder's address
+    //for a new one. This function is the only way to withdraw the remainder.
+    function updateRemainderAddress(address _remainderAddress) 
     external
+    onlyOwner()
+    noBalanceToShare()
+    {
+        address oldRemainderAddress = remainderAddress;
+        remainderAddress = _remainderAddress;
+
+        uint balance = token.balanceOf(address(this));
+
+        if(balance != 0) {
+            token.transfer(oldRemainderAddress, balance);
+        }
+    }
+
+    function getBalance()
+    external view
     returns (uint)
     {
         return token.balanceOf(address(this));
@@ -52,7 +70,7 @@ contract Collector is ICollector{
     onlyOwner()
     {
         uint balance = token.balanceOf(address(this));
-        require(balance > 0, "no revenue to share");
+        require(balance > partners.length, "no revenue to share");
 
         for(uint i = 0; i < partners.length; i++)
             token.transfer(partners[i].beneficiary, SafeMath.div(SafeMath.mul(balance, partners[i].share), 100));
@@ -68,17 +86,27 @@ contract Collector is ICollector{
     }
 
     modifier validShares(RevenuePartner[] memory _partners){
-        uint totalShares = 0;            
-        for(uint i = 0; i < _partners.length; i++)
+        uint totalShares = 0;
+
+        for(uint i = 0; i < _partners.length; i++){
             totalShares = totalShares + _partners[i].share;
+            require(_partners[i].share > 0, "0 is not a valid share");
+        }
 
         require(totalShares == 100, "total shares must add up to 100%");
-
         _;
     }
 
     modifier onlyOwner(){
-        require(msg.sender == owner, "can only call from owner");
+        require(msg.sender == owner, "only owner can call this");
+        _;
+    }
+
+    modifier noBalanceToShare(){
+        uint balance = token.balanceOf(address(this));
+
+        require(balance < partners.length, "there is balance to share");
+
         _;
     }
 }

--- a/deploy-collector.input.sample.json
+++ b/deploy-collector.input.sample.json
@@ -18,5 +18,6 @@
             "share": 32
         }
     ],
-    "tokenAddress": "0x5501F9dF7140fCD1E3091A6E8227E66C34d8913b"
+    "tokenAddress": "0x5501F9dF7140fCD1E3091A6E8227E66C34d8913b",
+    "remainderAddress": "0xc354D97642FAa06781b76Ffb6786f72cd7746C97"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "allowedTokens": "./scripts/allowedTokens",
     "prettier:fix": "npx prettier --write --ignore-unknown .",
     "prettier": "npx prettier --check .",
-    "test": "truffle test --network regtest"
+    "test:truffle": "truffle test --network regtest",
+    "test": "NODE_ENV=test mocha --timeout 10000"
   },
   "author": "Relaying Services Team",
   "license": "MIT",
@@ -39,6 +40,7 @@
     "@truffle/contract": "4.2.23",
     "@truffle/contract-schema": "3.3.2",
     "@truffle/hdwallet-provider": "1.6.0",
+    "chai": "^4.3.6",
     "npmignore": "^0.3.0",
     "patch-package": "~6.4.6",
     "truffle-hdwallet-provider": "~1.0.17"
@@ -51,6 +53,7 @@
     "@types/bn.js": "^4.11.6",
     "@types/chai": "^4.2.12",
     "@types/chai-as-promised": "^7.1.3",
+    "@types/mocha": "^9.1.1",
     "@types/eth-sig-util": "2.1.0",
     "@types/node": "~13.13.4",
     "@types/web3": "1.2.2",
@@ -63,6 +66,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "~7.30.0",
     "eth-gas-reporter": "^0.2.25",
+    "ethereum-waffle": "^3.4.4",
     "husky": "~6.0.0",
     "prettier": "^2.3.0",
     "solhint": "3.0.0",

--- a/tasks/deploy-collector.js
+++ b/tasks/deploy-collector.js
@@ -32,12 +32,14 @@ module.exports = async (callback) => {
     const {
         collectorOwner,
         partners: revenueSharingPartners,
-        tokenAddress
+        tokenAddress,
+        remainderAddress
     } = inputConfig;
     const collectorInstance = await Collector.new(
         collectorOwner,
         tokenAddress,
-        revenueSharingPartners
+        revenueSharingPartners,
+        remainderAddress
     );
     const deploymentReceipt = await web3.eth.getTransactionReceipt(
         collectorInstance.transactionHash
@@ -74,6 +76,9 @@ module.exports = async (callback) => {
         `| Collector Token                             | ${await collectorInstance.token.call()}       |`
     );
     console.log(
+        `| Collector Remainder                         | ${await collectorInstance.token.call()}       |`
+    );
+    console.log(
         '|=============================================|==================================================|\n'
     );
 
@@ -94,7 +99,8 @@ module.exports = async (callback) => {
     jsonConfig[networkId] = {
         collectorContract: collectorInstance.address,
         collectorOwner: await collectorInstance.owner.call(),
-        collectorToken: await collectorInstance.token.call()
+        collectorToken: await collectorInstance.token.call(),
+        remainderAddress: await collectorInstance.remainderAddress.call()
     };
 
     revenueSharingPartners.forEach(function (partner, i) {

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -1,0 +1,351 @@
+import { expect, use } from 'chai';
+import Collector from '../build/contracts/Collector.json';
+import TestToken from '../build/contracts/TestToken.json';
+import {
+    deployContract,
+    loadFixture,
+    MockProvider,
+    solidity
+} from 'ethereum-waffle';
+import { Wallet } from '@ethersproject/wallet';
+
+use(solidity);
+
+const FIRST_PARTNER_SHARE = 20;
+const SECOND_PARTNER_SHARE = 30;
+const THIRD_PARTNER_SHARE = 40;
+const FOURTH_PARTNER_SHARE = 10;
+
+const buildPartners = (partners: Wallet[], shares?: number[]) => {
+    return [
+        {
+            beneficiary: partners[0].getAddress(),
+            share: shares?.[0] ?? FIRST_PARTNER_SHARE
+        },
+        {
+            beneficiary: partners[1].getAddress(),
+            share: shares?.[1] ?? SECOND_PARTNER_SHARE
+        },
+        {
+            beneficiary: partners[2].getAddress(),
+            share: shares?.[2] ?? THIRD_PARTNER_SHARE
+        },
+        {
+            beneficiary: partners[3].getAddress(),
+            share: shares?.[3] ?? FOURTH_PARTNER_SHARE
+        }
+    ];
+};
+
+async function prepareAll(wallets: Wallet[]) {
+    const [
+        owner,
+        remainder,
+        partner1,
+        partner2,
+        partner3,
+        partner4,
+        utilWallet
+    ] = wallets;
+
+    const testToken = await deployContract(owner, TestToken);
+    const partners = buildPartners([partner1, partner2, partner3, partner4]);
+
+    const collector = await deployContract(owner, Collector, [
+        owner.address,
+        testToken.address,
+        partners,
+        remainder.address
+    ]);
+
+    return { collector, testToken, partners, remainder, utilWallet };
+}
+
+describe('Collector', () => {
+    async function prepareAllFixture(wallets: Wallet[]) {
+        return prepareAll(wallets);
+    }
+
+    describe('deployment', () => {
+        it('Should deploy with owner, token and revenue partners', async () => {
+            const { collector } = await loadFixture(prepareAllFixture);
+            expect(collector);
+        });
+
+        it('Should not let deploy with invalid shares', async () => {
+            const [owner, remainder, partner1, partner2, partner3, partner4] =
+                new MockProvider().getWallets();
+
+            const testToken = await deployContract(owner, TestToken);
+
+            const partners = buildPartners(
+                [partner1, partner2, partner3, partner4],
+                [25, 25, 25, 26]
+            );
+
+            await expect(
+                deployContract(owner, Collector, [
+                    owner.address,
+                    testToken.address,
+                    partners,
+                    remainder.address
+                ])
+            ).to.be.revertedWith('total shares must add up to 100%');
+        });
+
+        it('Should not let deploy if the array of partners is empty', async () => {
+            const [owner, remainder] = new MockProvider().getWallets();
+
+            const testToken = await deployContract(owner, TestToken);
+
+            const partners: Wallet[] = [];
+
+            await expect(
+                deployContract(owner, Collector, [
+                    owner.address,
+                    testToken.address,
+                    partners,
+                    remainder.address
+                ])
+            ).to.be.revertedWith('total shares must add up to 100%');
+        });
+
+        it('Should not let deploy if a share is 0', async () => {
+            const [owner, remainder, partner1, partner2, partner3, partner4] =
+                new MockProvider().getWallets();
+
+            const testToken = await deployContract(owner, TestToken);
+
+            const partners = buildPartners(
+                [partner1, partner2, partner3, partner4],
+                [30, 30, 0, 40]
+            );
+
+            await expect(
+                deployContract(owner, Collector, [
+                    owner.address,
+                    testToken.address,
+                    partners,
+                    remainder.address
+                ])
+            ).to.be.revertedWith('0 is not a valid share');
+        });
+    });
+
+    describe('updateShares', () => {
+        it('Should update shares and partners when token balance is zero', async () => {
+            const { collector } = await loadFixture(prepareAllFixture);
+
+            const newPartners = buildPartners(new MockProvider().getWallets());
+
+            await collector.updateShares(newPartners);
+            expect('updateShares').to.be.calledOnContract(collector);
+        });
+
+        it('Should update shares and partners when token balance is a remainder amount', async () => {
+            const { collector, testToken } = await loadFixture(
+                prepareAllFixture
+            );
+
+            await testToken.mint(3, collector.address);
+
+            const newPartners = buildPartners(new MockProvider().getWallets());
+
+            await collector.updateShares(newPartners);
+            expect('updateShares').to.be.calledOnContract(collector);
+        });
+
+        it('Should fail when token balance is grater than a remainder', async () => {
+            const { collector, testToken } = await loadFixture(
+                prepareAllFixture
+            );
+            await testToken.mint(100, collector.address);
+            const newPartners = buildPartners(new MockProvider().getWallets());
+            await expect(
+                collector.updateShares(newPartners)
+            ).to.be.revertedWith('there is balance to share');
+        });
+
+        it('Should fail when is called by an address that is not the owner', async () => {
+            const { collector, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+            const externallyLinkedCollector = collector.connect(
+                utilWallet.address
+            );
+            const newPartners = buildPartners(new MockProvider().getWallets());
+            await expect(
+                externallyLinkedCollector.updateShares(newPartners)
+            ).to.be.revertedWith('only owner can call this');
+        });
+
+        it('Should fail if the shares does not sum up to 100', async () => {
+            const { collector } = await loadFixture(prepareAllFixture);
+
+            const newPartners = buildPartners(
+                new MockProvider().getWallets(),
+                [25, 25, 24, 25]
+            );
+            await expect(
+                collector.updateShares(newPartners)
+            ).to.be.revertedWith('total shares must add up to 100%');
+        });
+
+        it('Should fail if a share is 0', async () => {
+            const { collector } = await loadFixture(prepareAllFixture);
+
+            const newPartners = buildPartners(
+                new MockProvider().getWallets(),
+                [50, 25, 25, 0]
+            );
+            await expect(
+                collector.updateShares(newPartners)
+            ).to.be.revertedWith('0 is not a valid share');
+        });
+    });
+
+    describe('updateRemainderAddress', () => {
+        it('Should update remainder address when token balance is zero', async () => {
+            const { collector, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+
+            await collector.updateRemainderAddress(utilWallet.address);
+            expect('updateRemainderAddress').to.be.calledOnContract(collector);
+        });
+
+        it('Should update remainder when token balance is a remainder and should withdraw remainder', async () => {
+            const { collector, testToken, remainder, utilWallet } =
+                await loadFixture(prepareAllFixture);
+            await testToken.mint(2, collector.address);
+
+            await collector.updateRemainderAddress(utilWallet.address);
+            expect('updateRemainderAddress').to.be.calledOnContract(collector);
+            expect(await testToken.balanceOf(collector.address)).to.equal(0);
+            expect(await testToken.balanceOf(remainder.address)).to.equal(2);
+        });
+
+        it('Should withdraw when the remainders address sent is the same as the current one', async () => {
+            const { collector, testToken, remainder } = await loadFixture(
+                prepareAllFixture
+            );
+            await testToken.mint(3, collector.address);
+
+            await collector.updateRemainderAddress(remainder.address);
+            expect('updateRemainderAddress').to.be.calledOnContract(collector);
+            expect(await testToken.balanceOf(collector.address)).to.equal(0);
+            expect(await testToken.balanceOf(remainder.address)).to.equal(3);
+        });
+
+        it('Should fail when token balance > = remainder', async () => {
+            const { collector, testToken, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+            await testToken.mint(4, collector.address);
+
+            await expect(
+                collector.updateRemainderAddress(utilWallet.address)
+            ).to.be.revertedWith('there is balance to share');
+        });
+
+        it('Should fail when is called by an address that is not the owner', async () => {
+            const { collector, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+            const externallyLinkedCollector = collector.connect(
+                utilWallet.address
+            );
+            await expect(
+                externallyLinkedCollector.updateRemainderAddress(
+                    utilWallet.address
+                )
+            ).to.be.revertedWith('only owner can call this');
+        });
+    });
+
+    describe('getBalance', () => {
+        it('Should return 0 if the contract has been just deployed', async () => {
+            const { collector } = await loadFixture(prepareAllFixture);
+            await expect(await collector.getBalance()).to.equal(0);
+        });
+
+        it('Should return 100 after that value has been minted', async () => {
+            const { collector, testToken } = await loadFixture(
+                prepareAllFixture
+            );
+            await testToken.mint(100, collector.address);
+            await expect(await collector.getBalance()).to.equal(100);
+        });
+    });
+
+    describe('withdraw', () => {
+        it('Should withdraw', async () => {
+            const { collector, testToken, partners } = await loadFixture(
+                prepareAllFixture
+            );
+
+            await testToken.mint(100, collector.address);
+            await collector.withdraw();
+
+            expect(await testToken.balanceOf(partners[0].beneficiary)).to.equal(
+                FIRST_PARTNER_SHARE
+            );
+            expect(await testToken.balanceOf(partners[1].beneficiary)).to.equal(
+                SECOND_PARTNER_SHARE
+            );
+            expect(await testToken.balanceOf(partners[2].beneficiary)).to.equal(
+                THIRD_PARTNER_SHARE
+            );
+            expect(await testToken.balanceOf(partners[3].beneficiary)).to.equal(
+                FOURTH_PARTNER_SHARE
+            );
+            expect(await testToken.balanceOf(collector.address)).to.equal(0);
+        });
+
+        it('Should fail when no revenue to share', async () => {
+            const { collector, testToken } = await loadFixture(
+                prepareAllFixture
+            );
+            await testToken.mint(1, collector.address);
+            await expect(collector.withdraw()).to.be.revertedWith(
+                'no revenue to share'
+            );
+        });
+
+        it('Should fail when is called by an address that is not the owner', async () => {
+            const { collector, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+            const externallyLinkedCollector = collector.connect(
+                utilWallet.address
+            );
+            await expect(
+                externallyLinkedCollector.withdraw()
+            ).to.be.revertedWith('only owner can call this');
+        });
+    });
+
+    describe('transferOwnership', () => {
+        it('Should transfer ownership', async () => {
+            const { collector, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+
+            await collector.transferOwnership(utilWallet.address);
+
+            expect(await collector.owner()).to.be.equal(utilWallet.address);
+        });
+
+        it('Should fail when is called by an address that is not the owner', async () => {
+            const { collector, utilWallet } = await loadFixture(
+                prepareAllFixture
+            );
+            const externallyLinkedCollector = collector.connect(
+                utilWallet.address
+            );
+            await expect(
+                externallyLinkedCollector.transferOwnership(utilWallet.address)
+            ).to.be.revertedWith('only owner can call this');
+        });
+    });
+});

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -223,21 +223,20 @@ describe('Collector', () => {
             expect('updateRemainderAddress').to.be.calledOnContract(collector);
         });
 
-        it('Should update remainder when token balance is a remainder and should withdraw remainder', async () => {
+        it.only('Should update remainder when token balance is a remainder and should withdraw remainder', async () => {
             const { collector, testToken, remainder, utilWallet } =
                 await loadFixture(prepareAllFixture);
             await testToken.mint(2, collector.address);
 
             await collector.updateRemainderAddress(utilWallet.address);
+
             expect(
                 'updateRemainderAddress',
                 'updateRemainderAddress() was never called'
             ).to.be.calledOnContract(collector);
             expect(
-                await testToken.balanceOf(
-                    collector.address,
-                    'The balance of the collector is wrong'
-                )
+                await testToken.balanceOf(collector.address),
+                'The balance of the collector is wrong'
             ).to.equal(0);
             expect(
                 await testToken.balanceOf(remainder.address),

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -49,7 +49,12 @@ async function prepareAll(wallets: Wallet[]) {
     ] = wallets;
 
     const testToken = await deployContract(owner, TestToken);
-    const partners = await buildPartners([partner1, partner2, partner3, partner4]);
+    const partners = await buildPartners([
+        partner1,
+        partner2,
+        partner3,
+        partner4
+    ]);
 
     const collector = await deployContract(owner, Collector, [
         owner.address,
@@ -136,7 +141,9 @@ describe('Collector', () => {
         it('Should update shares and partners when token balance is zero', async () => {
             const { collector } = await loadFixture(prepareAllFixture);
 
-            const newPartners = await buildPartners(new MockProvider().getWallets());
+            const newPartners = await buildPartners(
+                new MockProvider().getWallets()
+            );
 
             await collector.updateShares(newPartners);
             expect('updateShares').to.be.calledOnContract(collector);
@@ -149,7 +156,9 @@ describe('Collector', () => {
 
             await testToken.mint(3, collector.address);
 
-            const newPartners = await buildPartners(new MockProvider().getWallets());
+            const newPartners = await buildPartners(
+                new MockProvider().getWallets()
+            );
 
             await collector.updateShares(newPartners);
             expect('updateShares').to.be.calledOnContract(collector);
@@ -161,7 +170,9 @@ describe('Collector', () => {
             );
 
             await testToken.mint(100, collector.address);
-            const newPartners = await buildPartners(new MockProvider().getWallets());
+            const newPartners = await buildPartners(
+                new MockProvider().getWallets()
+            );
 
             await expect(
                 collector.updateShares(newPartners)
@@ -175,8 +186,10 @@ describe('Collector', () => {
             const externallyLinkedCollector = collector.connect(
                 utilWallet.address
             );
-            const newPartners = await buildPartners(new MockProvider().getWallets());
-            
+            const newPartners = await buildPartners(
+                new MockProvider().getWallets()
+            );
+
             await expect(
                 externallyLinkedCollector.updateShares(newPartners)
             ).to.be.revertedWith('Only owner can call this');
@@ -355,7 +368,7 @@ describe('Collector', () => {
             const externallyLinkedCollector = collector.connect(
                 utilWallet.address
             );
-            
+
             await expect(
                 externallyLinkedCollector.transferOwnership(utilWallet.address)
             ).to.be.revertedWith('Only owner can call this');

--- a/types/truffle-contracts/index.d.ts
+++ b/types/truffle-contracts/index.d.ts
@@ -18,6 +18,7 @@ export interface CollectorContract extends Truffle.Contract<CollectorInstance> {
     _owner: string | BN,
     _token: string | BN,
     _partners: { beneficiary: string | BN; share: number | BN | string }[],
+    _remainderAddress: string | BN,
     meta?: Truffle.TransactionDetails
   ): Promise<CollectorInstance>;
 }
@@ -639,14 +640,26 @@ export interface CollectorInstance extends Truffle.ContractInstance {
     ): Promise<number>;
   };
 
-  getBalance: {
-    (txDetails?: Truffle.TransactionDetails): Promise<
-      Truffle.TransactionResponse
-    >;
-    call(txDetails?: Truffle.TransactionDetails): Promise<BN>;
-    sendTransaction(txDetails?: Truffle.TransactionDetails): Promise<string>;
-    estimateGas(txDetails?: Truffle.TransactionDetails): Promise<number>;
+  updateRemainderAddress: {
+    (
+      _remainderAddress: string | BN,
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<Truffle.TransactionResponse>;
+    call(
+      _remainderAddress: string | BN,
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<void>;
+    sendTransaction(
+      _remainderAddress: string | BN,
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<string>;
+    estimateGas(
+      _remainderAddress: string | BN,
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<number>;
   };
+
+  getBalance(txDetails?: Truffle.TransactionDetails): Promise<BN>;
 
   withdraw: {
     (txDetails?: Truffle.TransactionDetails): Promise<

--- a/waffle.json
+++ b/waffle.json
@@ -1,0 +1,6 @@
+{
+    "compilerType": "solcjs",
+    "compilerVersion": "0.6.12",
+    "sourceDirectory": "./contracts",
+    "outputDirectory": "./build/contracts"
+}


### PR DESCRIPTION
## What

- Modify the Collector contract to properly manage the remainder. It was done introducing an additional wallet where the remainder can be sent.
- Additionally, in this PR Waffle is introduced as testing framework and the Collector is fully covered with unit testing.

## Why

- Currently one can only update partners when token balance = 0, but due to how integer division works in solidity, it is very likely that there will be a remainder after distributing all fees to the partners. A token amount of 999 that needs to be distributed to 4 partners would leave a remainder of balance = 3 after withdrawal.

## Refs

- [PP-130](https://rsklabs.atlassian.net/browse/PP-130)
