### PR TITLE
PP-325/REL-002

### DIFF
--- a/test/factory/CustomSmartWalletFactory.test.ts
+++ b/test/factory/CustomSmartWalletFactory.test.ts
@@ -1,4 +1,4 @@
-import { use, expect } from 'chai';
+import { use, expect, assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util';
 import { ethers } from 'ethers';
@@ -71,20 +71,20 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
     const ownerPrivateKey = toBuffer(generateBytes32(1));
     let ownerAddress: string;
 
-    beforeEach(async () => {
-        chainId = (await getTestingEnvironment()).chainId;
-        const smartWallet = await CustomSmartWallet.new();
-        factory = await CustomSmartWalletFactory.new(smartWallet.address);
-        ownerAddress = bufferToHex(
-            privateToAddress(ownerPrivateKey)
-        ).toLowerCase();
-    });
-
     describe('createUserSmartWallet', () => {
         const logicAddress = constants.ZERO_ADDRESS;
         const initParams = '0x';
         const recoverer = constants.ZERO_ADDRESS;
         const index = '0';
+
+        beforeEach(async () => {
+            chainId = (await getTestingEnvironment()).chainId;
+            const smartWallet = await CustomSmartWallet.new();
+            factory = await CustomSmartWalletFactory.new(smartWallet.address);
+            ownerAddress = bufferToHex(
+                privateToAddress(ownerPrivateKey)
+            ).toLowerCase();
+        });
 
         it('Should initiate the smart wallet in the expected address', async () => {
             const smartWalletAddress = await factory.getSmartWalletAddress(
@@ -95,7 +95,12 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 index
             );
 
-            expect(CustomSmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
+            /*   expect(CustomSmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
+                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
+            ); */
+
+            await assert.isRejected(
+                CustomSmartWallet.at(smartWalletAddress),
                 `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
             );
 
@@ -137,7 +142,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 }
             );
 
-            expect(
+            /*  expect(
                 factory.createUserSmartWallet(
                     constants.ZERO_ADDRESS,
                     recoverer,
@@ -147,6 +152,18 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     signatureCollapsed
                 )
             ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Invalid signature'
+            ); */
+
+            await assert.isRejected(
+                factory.createUserSmartWallet(
+                    constants.ZERO_ADDRESS,
+                    recoverer,
+                    logicAddress,
+                    index,
+                    initParams,
+                    signatureCollapsed
+                ),
                 'Returned error: VM Exception while processing transaction: revert Invalid signature'
             );
         });
@@ -163,7 +180,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 }
             );
 
-            expect(
+            /* expect(
                 factory.createUserSmartWallet(
                     otherAccount,
                     recoverer,
@@ -173,6 +190,18 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     signatureCollapsed
                 )
             ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Invalid signature'
+            ); */
+
+            await assert.isRejected(
+                factory.createUserSmartWallet(
+                    otherAccount,
+                    recoverer,
+                    logicAddress,
+                    index,
+                    initParams,
+                    signatureCollapsed
+                ),
                 'Returned error: VM Exception while processing transaction: revert Invalid signature'
             );
         });
@@ -185,6 +214,15 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
         const initParams = '0x';
         const recoverer = constants.ZERO_ADDRESS;
         const index = '0';
+
+        beforeEach(async () => {
+            chainId = (await getTestingEnvironment()).chainId;
+            const smartWallet = await CustomSmartWallet.new();
+            factory = await CustomSmartWalletFactory.new(smartWallet.address);
+            ownerAddress = bufferToHex(
+                privateToAddress(ownerPrivateKey)
+            ).toLowerCase();
+        });
 
         beforeEach(async () => {
             token = await TestToken.new();
@@ -201,7 +239,12 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
             const initialWorkerBalance = await getTokenBalance(token, worker);
             expect(initialWorkerBalance.toString()).to.be.equal('0');
 
-            expect(CustomSmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
+            /*   expect(CustomSmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
+                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
+            ); */
+
+            await assert.isRejected(
+                CustomSmartWallet.at(smartWalletAddress),
                 `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
             );
 
@@ -379,7 +422,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 chainId
             );
 
-            expect(
+            /* expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -389,6 +432,18 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Unable to initialize SW'
+            ); */
+
+            await assert.isRejected(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    signature,
+                    {
+                        from: worker
+                    }
+                ),
                 'Returned error: VM Exception while processing transaction: revert Unable to initialize SW'
             );
         });
@@ -417,7 +472,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 chainId
             );
 
-            expect(
+            /*  expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -427,6 +482,18 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Invalid caller'
+            ); */
+
+            await assert.isRejected(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    signature,
+                    {
+                        from: worker
+                    }
+                ),
                 'Returned error: VM Exception while processing transaction: revert Invalid caller'
             );
         });
@@ -456,7 +523,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 chainId
             );
 
-            expect(
+            /* expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -466,6 +533,18 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert nonce mismatch'
+            ); */
+
+            await assert.isRejected(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    signature,
+                    {
+                        from: worker
+                    }
+                ),
                 'Returned error: VM Exception while processing transaction: revert nonce mismatch'
             );
         });
@@ -495,7 +574,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
 
             relayRequest.request.from = otherAccount;
 
-            expect(
+            /*  expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -505,6 +584,18 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Signature mismatch'
+            ); */
+
+            await assert.isRejected(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    signature,
+                    {
+                        from: worker
+                    }
+                ),
                 'Returned error: VM Exception while processing transaction: revert Signature mismatch'
             );
         });

--- a/test/factory/CustomSmartWalletFactory.test.ts
+++ b/test/factory/CustomSmartWalletFactory.test.ts
@@ -1,0 +1,362 @@
+import { use, assert } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util';
+import { ethers } from 'ethers';
+import { soliditySha3Raw } from 'web3-utils';
+import {
+    CustomSmartWalletFactoryInstance,
+    CustomSmartWalletInstance,
+    TestTokenInstance
+} from '../../types/truffle-contracts';
+import { constants } from '../constants';
+import {
+    createRequest,
+    generateBytes32,
+    getTestingEnvironment,
+    getTokenBalance,
+    mintTokens,
+    signRequest
+} from '../utils';
+
+use(chaiAsPromised);
+
+const CustomSmartWallet = artifacts.require('CustomSmartWallet');
+const CustomSmartWalletFactory = artifacts.require('CustomSmartWalletFactory');
+const TestToken = artifacts.require('TestToken');
+
+type createUserSmartWalletParam = {
+    owner: string;
+    recoverer: string;
+    logicAddress: string;
+    index: string;
+    initParams: string;
+};
+
+/**
+ * Function to get the actual token balance for an account
+ * @param ownerAddress
+ * @param ownerPrivateKey
+ * @param recoverer
+ * @param logicAddress
+ * @param index
+ * @param initParams
+ * @returns The createUserSmartWallet signed
+ */
+function createUserSmartWalletSignature(
+    ownerPrivateKey: Buffer,
+    object: createUserSmartWalletParam
+): string {
+    const { owner, recoverer, logicAddress, index, initParams } = object;
+
+    const toSign: string =
+        web3.utils.soliditySha3(
+            { t: 'bytes2', v: '0x1910' },
+            { t: 'address', v: owner },
+            { t: 'address', v: recoverer },
+            { t: 'address', v: logicAddress },
+            { t: 'uint256', v: index },
+            { t: 'bytes', v: initParams }
+        ) ?? '';
+    const toSignAsBinaryArray = ethers.utils.arrayify(toSign);
+    const signingKey = new ethers.utils.SigningKey(ownerPrivateKey);
+    const signature = signingKey.signDigest(toSignAsBinaryArray);
+    const signatureCollapsed = ethers.utils.joinSignature(signature);
+
+    return signatureCollapsed;
+}
+
+contract('CustomSmartWalletFactory', ([worker]) => {
+    let chainId: number;
+    let factory: CustomSmartWalletFactoryInstance;
+    const ownerPrivateKey = toBuffer(generateBytes32(1));
+    let ownerAddress: string;
+
+    beforeEach(async () => {
+        chainId = (await getTestingEnvironment()).chainId;
+        const smartWallet = await CustomSmartWallet.new();
+        factory = await CustomSmartWalletFactory.new(smartWallet.address);
+        ownerAddress = bufferToHex(
+            privateToAddress(ownerPrivateKey)
+        ).toLowerCase();
+    });
+
+    describe('createUserSmartWallet', () => {
+        const logicAddress = constants.ZERO_ADDRESS;
+        const initParams = '0x';
+        const recoverer = constants.ZERO_ADDRESS;
+        const index = '0';
+
+        it('Should initiate the smart wallet in the expected address', async () => {
+            const smartWalletAddress = await factory.getSmartWalletAddress(
+                ownerAddress,
+                recoverer,
+                logicAddress,
+                soliditySha3Raw({ t: 'bytes', v: initParams }),
+                index
+            );
+
+            await assert.isRejected(
+                CustomSmartWallet.at(smartWalletAddress),
+                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
+            );
+
+            const signatureCollapsed = createUserSmartWalletSignature(
+                ownerPrivateKey,
+                {
+                    owner: ownerAddress,
+                    recoverer,
+                    logicAddress,
+                    initParams,
+                    index
+                }
+            );
+
+            await factory.createUserSmartWallet(
+                ownerAddress,
+                recoverer,
+                logicAddress,
+                index,
+                initParams,
+                signatureCollapsed
+            );
+
+            const smartWallet: CustomSmartWalletInstance =
+                await CustomSmartWallet.at(smartWalletAddress);
+
+            await assert.eventually.isTrue(smartWallet.isInitialized());
+        });
+
+        it('Should verify method initialize fails with a ZERO owner address parameter', async () => {
+            const signatureCollapsed = createUserSmartWalletSignature(
+                ownerPrivateKey,
+                {
+                    owner: constants.ZERO_ADDRESS,
+                    recoverer,
+                    logicAddress,
+                    initParams,
+                    index
+                }
+            );
+
+            await assert.isRejected(
+                factory.createUserSmartWallet(
+                    constants.ZERO_ADDRESS,
+                    recoverer,
+                    logicAddress,
+                    index,
+                    initParams,
+                    signatureCollapsed
+                ),
+                'Returned error: VM Exception while processing transaction: revert Invalid signature'
+            );
+        });
+    });
+
+    describe('relayedUserSmartWalletCreation', () => {
+        let token: TestTokenInstance;
+        const logicAddress = constants.ZERO_ADDRESS;
+        const initParams = '0x';
+        const recoverer = constants.ZERO_ADDRESS;
+        const index = '0';
+
+        beforeEach(async () => {
+            token = await TestToken.new();
+        });
+
+        it('Should initialize the smart wallet in the expected address without paying fee', async () => {
+            const smartWalletAddress = await factory.getSmartWalletAddress(
+                ownerAddress,
+                recoverer,
+                logicAddress,
+                soliditySha3Raw({ t: 'bytes', v: initParams }),
+                index
+            );
+
+            const initialWorkerBalance = await getTokenBalance(token, worker);
+            assert.equal(initialWorkerBalance.toString(), '0');
+
+            await assert.isRejected(
+                CustomSmartWallet.at(smartWalletAddress),
+                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
+            );
+
+            const relayRequest = createRequest(
+                {
+                    from: ownerAddress,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '0',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                ownerPrivateKey,
+                relayRequest,
+                chainId
+            );
+
+            await factory.relayedUserSmartWalletCreation(
+                relayRequest.request,
+                suffixData,
+                signature,
+                {
+                    from: worker
+                }
+            );
+
+            const smartWallet: CustomSmartWalletInstance =
+                await CustomSmartWallet.at(smartWalletAddress);
+
+            await assert.eventually.isTrue(smartWallet.isInitialized());
+
+            const finalWorkerBalance = await getTokenBalance(token, worker);
+            assert.equal(finalWorkerBalance.toString(), '0');
+        });
+
+        it('Should initialize the smart wallet in the expected address paying fee', async () => {
+            const smartWalletAddress = await factory.getSmartWalletAddress(
+                ownerAddress,
+                recoverer,
+                logicAddress,
+                soliditySha3Raw({ t: 'bytes', v: initParams }),
+                index
+            );
+
+            const initialWorkerBalance = await getTokenBalance(token, worker);
+            assert.equal(initialWorkerBalance.toString(), '0');
+
+            await mintTokens(token, smartWalletAddress, '1000');
+
+            await assert.isRejected(
+                CustomSmartWallet.at(smartWalletAddress),
+                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
+            );
+
+            const fee = '500';
+
+            const relayRequest = createRequest(
+                {
+                    from: ownerAddress,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: fee,
+                    tokenGas: '50000',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                ownerPrivateKey,
+                relayRequest,
+                chainId
+            );
+
+            await factory.relayedUserSmartWalletCreation(
+                relayRequest.request,
+                suffixData,
+                signature,
+                {
+                    from: worker
+                }
+            );
+
+            const smartWallet: CustomSmartWalletInstance =
+                await CustomSmartWallet.at(smartWalletAddress);
+
+            await assert.eventually.isTrue(smartWallet.isInitialized());
+
+            const finalWorkerBalance = await getTokenBalance(token, worker);
+            assert.equal(finalWorkerBalance.toString(), fee);
+        });
+
+        it('Should verify method initialize reverts with negative token amount', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: ownerAddress,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '-100',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            assert.throw(
+                () => signRequest(ownerPrivateKey, relayRequest, chainId),
+                'Supplied uint is negative'
+            );
+        });
+
+        it('Should verify method initialize successfully with token as ZERO address parameter', async () => {
+            const smartWalletAddress = await factory.getSmartWalletAddress(
+                ownerAddress,
+                recoverer,
+                logicAddress,
+                soliditySha3Raw({ t: 'bytes', v: initParams }),
+                index
+            );
+
+            await assert.isRejected(
+                CustomSmartWallet.at(smartWalletAddress),
+                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
+            );
+
+            const relayRequest = createRequest(
+                {
+                    from: ownerAddress,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: constants.ZERO_ADDRESS,
+                    tokenAmount: '0',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                ownerPrivateKey,
+                relayRequest,
+                chainId
+            );
+
+            await factory.relayedUserSmartWalletCreation(
+                relayRequest.request,
+                suffixData,
+                signature,
+                {
+                    from: worker
+                }
+            );
+
+            const smartWallet: CustomSmartWalletInstance =
+                await CustomSmartWallet.at(smartWalletAddress);
+
+            await assert.eventually.isTrue(smartWallet.isInitialized());
+        });
+    });
+});

--- a/test/factory/CustomSmartWalletFactory.test.ts
+++ b/test/factory/CustomSmartWalletFactory.test.ts
@@ -1,4 +1,4 @@
-import { use, expect, assert } from 'chai';
+import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util';
 import { ethers } from 'ethers';
@@ -95,12 +95,9 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 index
             );
 
-            /*   expect(CustomSmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
-                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
-            ); */
-
-            await assert.isRejected(
-                CustomSmartWallet.at(smartWalletAddress),
+            await expect(
+                CustomSmartWallet.at(smartWalletAddress)
+            ).to.be.rejectedWith(
                 `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
             );
 
@@ -127,7 +124,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
             const smartWallet: CustomSmartWalletInstance =
                 await CustomSmartWallet.at(smartWalletAddress);
 
-            expect(smartWallet.isInitialized()).to.eventually.be.true;
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
         });
 
         it('Should fail with a ZERO owner address parameter', async () => {
@@ -142,7 +139,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 }
             );
 
-            /*  expect(
+            await expect(
                 factory.createUserSmartWallet(
                     constants.ZERO_ADDRESS,
                     recoverer,
@@ -152,18 +149,6 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     signatureCollapsed
                 )
             ).to.be.rejectedWith(
-                'Returned error: VM Exception while processing transaction: revert Invalid signature'
-            ); */
-
-            await assert.isRejected(
-                factory.createUserSmartWallet(
-                    constants.ZERO_ADDRESS,
-                    recoverer,
-                    logicAddress,
-                    index,
-                    initParams,
-                    signatureCollapsed
-                ),
                 'Returned error: VM Exception while processing transaction: revert Invalid signature'
             );
         });
@@ -180,7 +165,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 }
             );
 
-            /* expect(
+            await expect(
                 factory.createUserSmartWallet(
                     otherAccount,
                     recoverer,
@@ -190,18 +175,6 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     signatureCollapsed
                 )
             ).to.be.rejectedWith(
-                'Returned error: VM Exception while processing transaction: revert Invalid signature'
-            ); */
-
-            await assert.isRejected(
-                factory.createUserSmartWallet(
-                    otherAccount,
-                    recoverer,
-                    logicAddress,
-                    index,
-                    initParams,
-                    signatureCollapsed
-                ),
                 'Returned error: VM Exception while processing transaction: revert Invalid signature'
             );
         });
@@ -239,12 +212,9 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
             const initialWorkerBalance = await getTokenBalance(token, worker);
             expect(initialWorkerBalance.toString()).to.be.equal('0');
 
-            /*   expect(CustomSmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
-                `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
-            ); */
-
-            await assert.isRejected(
-                CustomSmartWallet.at(smartWalletAddress),
+            await expect(
+                CustomSmartWallet.at(smartWalletAddress)
+            ).to.be.rejectedWith(
                 `Cannot create instance of CustomSmartWallet; no code at address ${smartWalletAddress}`
             );
 
@@ -283,10 +253,10 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
             const smartWallet: CustomSmartWalletInstance =
                 await CustomSmartWallet.at(smartWalletAddress);
 
-            expect(smartWallet.isInitialized()).to.eventually.be.true;
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
 
             const finalWorkerBalance = await getTokenBalance(token, worker);
-            expect(finalWorkerBalance.toString()).to.be.equal('0');
+            await expect(finalWorkerBalance.toString()).to.be.equal('0');
         });
 
         it('Should initialize the smart wallet in the expected address paying fee', async () => {
@@ -331,10 +301,10 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
             const smartWallet: CustomSmartWalletInstance =
                 await CustomSmartWallet.at(smartWalletAddress);
 
-            expect(smartWallet.isInitialized()).to.eventually.be.true;
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
 
             const finalWorkerBalance = await getTokenBalance(token, worker);
-            expect(finalWorkerBalance.toString()).to.be.equal(fee);
+            await expect(finalWorkerBalance.toString()).to.be.equal(fee);
         });
 
         it('Should fail with negative token amount', async () => {
@@ -395,7 +365,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
             const smartWallet: CustomSmartWalletInstance =
                 await CustomSmartWallet.at(smartWalletAddress);
 
-            expect(smartWallet.isInitialized()).to.eventually.be.true;
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
         });
 
         it('Should fail when owner does not have funds to pay', async () => {
@@ -422,7 +392,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 chainId
             );
 
-            /* expect(
+            await expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -432,18 +402,6 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
-                'Returned error: VM Exception while processing transaction: revert Unable to initialize SW'
-            ); */
-
-            await assert.isRejected(
-                factory.relayedUserSmartWalletCreation(
-                    relayRequest.request,
-                    suffixData,
-                    signature,
-                    {
-                        from: worker
-                    }
-                ),
                 'Returned error: VM Exception while processing transaction: revert Unable to initialize SW'
             );
         });
@@ -472,7 +430,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 chainId
             );
 
-            /*  expect(
+            await expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -482,18 +440,6 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
-                'Returned error: VM Exception while processing transaction: revert Invalid caller'
-            ); */
-
-            await assert.isRejected(
-                factory.relayedUserSmartWalletCreation(
-                    relayRequest.request,
-                    suffixData,
-                    signature,
-                    {
-                        from: worker
-                    }
-                ),
                 'Returned error: VM Exception while processing transaction: revert Invalid caller'
             );
         });
@@ -523,7 +469,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                 chainId
             );
 
-            /* expect(
+            await expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -533,18 +479,6 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
-                'Returned error: VM Exception while processing transaction: revert nonce mismatch'
-            ); */
-
-            await assert.isRejected(
-                factory.relayedUserSmartWalletCreation(
-                    relayRequest.request,
-                    suffixData,
-                    signature,
-                    {
-                        from: worker
-                    }
-                ),
                 'Returned error: VM Exception while processing transaction: revert nonce mismatch'
             );
         });
@@ -574,7 +508,7 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
 
             relayRequest.request.from = otherAccount;
 
-            /*  expect(
+            await expect(
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
@@ -584,18 +518,6 @@ contract('CustomSmartWalletFactory', ([worker, otherAccount]) => {
                     }
                 )
             ).to.be.rejectedWith(
-                'Returned error: VM Exception while processing transaction: revert Signature mismatch'
-            ); */
-
-            await assert.isRejected(
-                factory.relayedUserSmartWalletCreation(
-                    relayRequest.request,
-                    suffixData,
-                    signature,
-                    {
-                        from: worker
-                    }
-                ),
                 'Returned error: VM Exception while processing transaction: revert Signature mismatch'
             );
         });

--- a/test/relayHub/RelayHub.test.ts
+++ b/test/relayHub/RelayHub.test.ts
@@ -734,6 +734,16 @@ contract(
                     from: relayOwner
                 });
 
+                const stakeInfo = await relayHubInstance.getStakeInfo(
+                    relayManager
+                );
+
+                assert.equal(
+                    stakeInfo.owner,
+                    constants.ZERO_ADDRESS,
+                    'sender is a relayManager itself'
+                );
+
                 await assert.isRejected(
                     relayHubInstance.stakeForAddress(_, 1000, {
                         value: ether('1'),

--- a/test/relayHub/RelayHub.test.ts
+++ b/test/relayHub/RelayHub.test.ts
@@ -5,7 +5,6 @@ import {
     DeployRequest,
     cloneDeployRequest,
     TypedRequestData,
-    getDomainSeparatorHash,
     TypedDeployRequestData
 } from '../../';
 
@@ -38,7 +37,7 @@ import {
     TestDeployVerifierEverythingAcceptedInstance
 } from '../../types/truffle-contracts';
 import chaiAsPromised from 'chai-as-promised';
-// import { AccountKeypair } from '@rsksmart/rif-relay-client';
+import { AccountKeypair } from '@rsksmart/rif-relay-client';
 import { toBN } from 'web3-utils';
 
 import chai from 'chai';
@@ -82,7 +81,7 @@ contract(
                     from: relayOwner
                 });
 
-                //Getting the relaay workers count before adding a new worker
+                //Getting the relay workers count before adding a new worker
                 const relayWorkersBefore = await relayHubInstance.workerCount(
                     relayManager
                 );
@@ -741,7 +740,7 @@ contract(
                         from: relayManager
                     }),
                     'sender is a relayManager itself',
-                    'Stake was made with less value than the minimum'
+                    'Stake was made with proper relayManager'
                 );
             });
         });
@@ -801,11 +800,7 @@ contract(
                         gasPrice,
                         relayWorker,
                         callForwarder: forwarder,
-                        callVerifier: verifier,
-                        domainSeparator: getDomainSeparatorHash(
-                            forwarder,
-                            chainId
-                        )
+                        callVerifier: verifier
                     }
                 };
 
@@ -998,11 +993,7 @@ contract(
                         gasPrice,
                         relayWorker,
                         callForwarder: factory.address,
-                        callVerifier: deployVerifierContract.address,
-                        domainSeparator: getDomainSeparatorHash(
-                            factory.address,
-                            chainId
-                        )
+                        callVerifier: deployVerifierContract.address
                     }
                 };
 

--- a/test/smartwallet/CustomSmartWallet.template.test.ts
+++ b/test/smartwallet/CustomSmartWallet.template.test.ts
@@ -1,0 +1,42 @@
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { CustomSmartWalletInstance } from '../../types/truffle-contracts';
+import { constants } from '../constants';
+
+use(chaiAsPromised);
+
+const CustomSmartWallet = artifacts.require('CustomSmartWallet');
+
+contract('CustomSmartWallet - template', ([owner]) => {
+    describe('initialize', () => {
+        let smartWallet: CustomSmartWalletInstance;
+
+        beforeEach(async () => {
+            smartWallet = await CustomSmartWallet.new();
+        });
+
+        it('Should be initialized during the deployment', async () => {
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
+        });
+
+        it('Should verify method initialize fails when contract has already deployed', async () => {
+            const logicAddress = constants.ZERO_ADDRESS;
+            const initParams = '0x';
+            const tokenAddress = constants.ZERO_ADDRESS;
+            const recipient = constants.ZERO_ADDRESS;
+
+            await expect(
+                smartWallet.initialize(
+                    owner,
+                    logicAddress,
+                    tokenAddress,
+                    recipient,
+                    '0',
+                    '5000',
+                    initParams
+                )
+            ).to.be.rejectedWith('already initialized');
+        });
+    });
+});

--- a/test/smartwallet/customSmartWallet.test.ts
+++ b/test/smartwallet/customSmartWallet.test.ts
@@ -2,7 +2,8 @@ import {
     TestTokenInstance,
     CustomSmartWalletInstance,
     SuccessCustomLogicInstance,
-    TestForwarderTargetInstance
+    TestForwarderTargetInstance,
+    CustomSmartWalletFactoryInstance
 } from '../../types/truffle-contracts';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -25,7 +26,9 @@ import { constants } from '../constants';
 import {
     generateBytes32,
     getTestingEnvironment,
-    containsEvent
+    containsEvent,
+    createCustomSmartWallet,
+    createCustomSmartWalletFactory
 } from '../utils';
 
 chai.use(chaiAsPromised);
@@ -140,6 +143,8 @@ contract(
         let senderAddress: string;
         let customLogic: SuccessCustomLogicInstance;
         let smartWallet: CustomSmartWalletInstance;
+        let factory: CustomSmartWalletFactoryInstance;
+        let chainId: number;
         const senderPrivateKey = toBuffer(generateBytes32(1));
 
         describe('Testing initialize and isInitialize methods and values for parameters', () => {
@@ -147,288 +152,40 @@ contract(
                 'Setting senderAccount, Contract instance and Test Token',
                 async () => {
                     // Initializing all the variables and instances for each test
-                    smartWallet = await CustomSmartWallet.new();
+                    chainId = (await getTestingEnvironment()).chainId;
                     customLogic = await SuccessCustomLogic.new();
                     token = await TestToken.new();
                     senderAddress = bufferToHex(
                         privateToAddress(senderPrivateKey)
                     ).toLowerCase();
+                    const smartWalletTemplate = await CustomSmartWallet.new();
+                    factory = await createCustomSmartWalletFactory(
+                        smartWalletTemplate
+                    );
                 }
             );
 
-            it('Should verify method initialize fails with a null sender address parameter', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        null,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize fails with a ZERO owner address parameter', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        constants.ZERO_ADDRESS,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '10',
-                        '400000',
-                        '0x'
-                    ),
-                    'Unable to pay for deployment',
-                    'Error while validating data'
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize fails with a null token address parameter', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        null,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize reverts with negative gas amount', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '100',
-                        '-400000',
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize reverts with negative token amount', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '-2',
-                        '400000',
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize successfully with token as 0x address parameter', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        constants.ZERO_ADDRESS,
-                        worker,
-                        '10',
-                        '400000',
-                        '0x'
-                    )
+            it('Should initialize the smart wallet properly', async () => {
+                smartWallet = await createCustomSmartWallet(
+                    worker,
+                    senderAddress,
+                    factory,
+                    senderPrivateKey,
+                    chainId
                 );
 
                 assert.isTrue(await smartWallet.isInitialized());
-            });
-
-            it('Should fail to initialize the smart wallet if the worker address is null', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        null,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize reverts with gas amount as null', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        null,
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize successfully with all address type parameters as zero address', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        constants.ZERO_ADDRESS,
-                        constants.ZERO_ADDRESS,
-                        constants.ZERO_ADDRESS,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
-                assert.isTrue(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize successfully return with 0 tokens', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
-                //After initialization is complete the method should return true
-                assert.isTrue(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize fails due to amount greater than 0 and gas less than 0', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '10',
-                        '-10',
-                        '0x'
-                    )
-                );
-
-                //After initialization is complete the method should return true
-                assert.equal(await smartWallet.isInitialized(), false);
-            });
-
-            it('Should verify method initialize fails due to amount greater than 0 and ZERO token address', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '-400000',
-                        '0x'
-                    )
-                );
-
-                assert.isFalse(await smartWallet.isInitialized());
-            });
-
-            it('Should verify method initialize fails when owner does not have funds to pay', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-
-                //Initializing the contract
-                await assert.isRejected(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        constants.ZERO_ADDRESS,
-                        worker,
-                        '10',
-                        '-400000',
-                        '0x'
-                    )
-                );
-
-                //After initialization is complete the method should return true
-                assert.isFalse(await smartWallet.isInitialized());
             });
 
             it('Should verify method initialize fails when contract has already been initialized', async () => {
-                //Making sure the contract has not been initialized yet
-                assert.isFalse(await smartWallet.isInitialized());
-
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
+                smartWallet = await createCustomSmartWallet(
+                    worker,
+                    senderAddress,
+                    factory,
+                    senderPrivateKey,
+                    chainId
                 );
 
-                //After initialization is complete the method should return true
                 assert.isTrue(await smartWallet.isInitialized());
 
                 await assert.isRejected(
@@ -456,7 +213,6 @@ contract(
         describe('Testing verify method for values and parameters', () => {
             let token: TestTokenInstance;
             let senderAddress: string;
-            let customLogic: SuccessCustomLogicInstance;
             let smartWallet: CustomSmartWalletInstance;
             let chainId: number;
             const senderPrivateKey = toBuffer(generateBytes32(1));
@@ -465,11 +221,21 @@ contract(
             let relayData: Partial<RelayData>;
 
             beforeEach('Setting senderAccount and Test Token', async () => {
+                chainId = (await getTestingEnvironment()).chainId;
                 senderAddress = bufferToHex(
                     privateToAddress(senderPrivateKey)
                 ).toLowerCase();
-                smartWallet = await CustomSmartWallet.new();
-                customLogic = await SuccessCustomLogic.new();
+                const smartWalletTemplate = await CustomSmartWallet.new();
+                const factory = await createCustomSmartWalletFactory(
+                    smartWalletTemplate
+                );
+                smartWallet = await createCustomSmartWallet(
+                    worker,
+                    senderAddress,
+                    factory,
+                    senderPrivateKey,
+                    chainId
+                );
                 token = await TestToken.new();
                 recipient = await TestForwarderTarget.new();
                 recipientFunction = recipient.contract.methods
@@ -503,24 +269,10 @@ contract(
             });
 
             it('Should verify method verify revert because owner is not the owner of the smart wallet', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
                 //Initializing the contract
                 const senderAccount = web3.eth.accounts.create();
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAccount.address,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
 
                 assert.isTrue(await smartWallet.isInitialized());
-
-                chainId = (await getTestingEnvironment()).chainId;
 
                 const initialNonce = await smartWallet.nonce();
 
@@ -531,12 +283,12 @@ contract(
                         nonce: initialNonce.toString(),
                         relayHub: worker,
                         tokenContract: token.address,
-                        from: senderAddress
+                        from: senderAccount.address
                     },
                     relayData
                 );
 
-                relayRequest.request.from = smartWallet.address;
+                relayRequest.relayData.callForwarder = smartWallet.address;
 
                 const { signature, suffixData } = signRequest(
                     senderPrivateKey,
@@ -556,24 +308,7 @@ contract(
             });
 
             it('Should verify method verify revert because nonce mismatch', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-                chainId = (await getTestingEnvironment()).chainId;
-
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
-                chainId = (await getTestingEnvironment()).chainId;
 
                 const relayRequest = createRequest(
                     {
@@ -586,6 +321,8 @@ contract(
                     },
                     relayData
                 );
+
+                relayRequest.relayData.callForwarder = smartWallet.address;
 
                 const { signature, suffixData } = signRequest(
                     senderPrivateKey,
@@ -605,23 +342,7 @@ contract(
             });
 
             it('Should verify method verify and revert because of signature mismatch', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
-                chainId = (await getTestingEnvironment()).chainId;
 
                 const initialNonce = await smartWallet.nonce();
 
@@ -655,24 +376,7 @@ contract(
             });
 
             it('Should verify method successfully sign a txn', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-
-                //Initializing the contract
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAddress,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
-
-                chainId = (await getTestingEnvironment()).chainId;
 
                 const initialNonce = await smartWallet.nonce();
                 const relayRequest = createRequest(
@@ -714,7 +418,6 @@ contract(
         describe('Testing execute method for values and parameters', () => {
             let token: TestTokenInstance;
             let senderAddress: string;
-            let customLogic: SuccessCustomLogicInstance;
             let smartWallet: CustomSmartWalletInstance;
             let chainId: number;
             const senderPrivateKey = toBuffer(generateBytes32(1));
@@ -723,41 +426,37 @@ contract(
             let relayData: Partial<RelayData>;
 
             beforeEach('Setting values', async () => {
+                chainId = (await getTestingEnvironment()).chainId;
                 senderAddress = bufferToHex(
                     privateToAddress(senderPrivateKey)
                 ).toLowerCase();
-                smartWallet = await CustomSmartWallet.new();
-                customLogic = await SuccessCustomLogic.new();
                 token = await TestToken.new();
                 recipient = await TestForwarderTarget.new();
-                chainId = (await getTestingEnvironment()).chainId;
                 recipientFunction = recipient.contract.methods
                     .emitMessage('hello')
                     .encodeABI();
+                const smartWalletTemplate = await CustomSmartWallet.new();
+                const factory = await createCustomSmartWalletFactory(
+                    smartWalletTemplate
+                );
+                smartWallet = await createCustomSmartWallet(
+                    worker,
+                    senderAddress,
+                    factory,
+                    senderPrivateKey,
+                    chainId
+                );
                 relayData = {
                     callForwarder: smartWallet.address
                 };
             });
 
             it('Should verify the method executed revert to the Invalid caller', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
                 //Initializing the contract
                 const senderAccount = web3.eth.accounts.create();
-                await assert.isFulfilled(
-                    smartWallet.initialize(
-                        senderAccount.address,
-                        customLogic.address,
-                        token.address,
-                        worker,
-                        '0',
-                        '400000',
-                        '0x'
-                    )
-                );
 
                 assert.isTrue(await smartWallet.isInitialized());
 
-                chainId = (await getTestingEnvironment()).chainId;
                 const initialNonce = await smartWallet.nonce();
 
                 const relayRequest = await createRequest(
@@ -767,12 +466,10 @@ contract(
                         nonce: initialNonce.toString(),
                         relayHub: senderAddress, //To make it fail
                         tokenContract: token.address,
-                        from: senderAddress
+                        from: senderAccount.address
                     },
                     relayData
                 );
-
-                const senderPrivateKey = toBuffer(generateBytes32(1));
 
                 recipient = await TestForwarderTarget.new();
                 recipientFunction = recipient.contract.methods
@@ -798,18 +495,6 @@ contract(
             });
 
             it('Should verify the method executed revert to Unable to pay relay', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-
-                await smartWallet.initialize(
-                    senderAddress,
-                    customLogic.address,
-                    token.address,
-                    worker,
-                    '0',
-                    '400000',
-                    '0x'
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
 
                 const initialNonce = await smartWallet.nonce();
@@ -824,7 +509,7 @@ contract(
                     },
                     relayData
                 );
-                relayRequest.relayData.callForwarder = smartWallet.address;
+
                 const { signature, suffixData } = signRequest(
                     senderPrivateKey,
                     relayRequest,
@@ -844,18 +529,6 @@ contract(
             });
 
             it('Should verify the method executed reverts to Not enough gas', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-
-                await smartWallet.initialize(
-                    senderAddress,
-                    customLogic.address,
-                    token.address,
-                    worker,
-                    '0',
-                    '400000',
-                    '0x'
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
 
                 const initialNonce = await smartWallet.nonce();
@@ -891,18 +564,6 @@ contract(
             });
 
             it('Should verify the method executed success for transfer with 0 tokenAmount', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-
-                await smartWallet.initialize(
-                    senderAddress,
-                    customLogic.address,
-                    token.address,
-                    worker,
-                    '0',
-                    '400000',
-                    '0x'
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
 
                 const initialNonce = await smartWallet.nonce();
@@ -942,20 +603,7 @@ contract(
 
             it('Should verify the method executed success to same sender and receiver', async () => {
                 const transferAmount = 1000;
-                assert.isFalse(await smartWallet.isInitialized());
-
-                await smartWallet.initialize(
-                    senderAddress,
-                    customLogic.address,
-                    token.address,
-                    worker,
-                    '0',
-                    '400000',
-                    '0x'
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
-
                 const initialNonce = await smartWallet.nonce();
                 const initialBalance = getTokenBalance(token, senderAddress);
                 const relayRequest = createRequest(
@@ -1004,21 +652,8 @@ contract(
 
             it('Should verify balances after a transaction between accounts', async () => {
                 const transferAmount = 1000;
-                assert.isFalse(await smartWallet.isInitialized());
-
-                await smartWallet.initialize(
-                    senderAddress,
-                    customLogic.address,
-                    token.address,
-                    worker,
-                    '0',
-                    '400000',
-                    '0x'
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
                 const initialNonce = await smartWallet.nonce();
-
                 const initialWorkerTokenBalance = await getTokenBalance(
                     token,
                     worker
@@ -1101,20 +736,35 @@ contract(
     'Custom SmartWallet contract - Unit testing on directExecute method',
     ([worker, fundedAccount]) => {
         describe('Testing directExecute method for values and parameters', () => {
-            let token: TestTokenInstance;
             let customLogic: SuccessCustomLogicInstance;
             let smartWallet: CustomSmartWalletInstance;
             let recipientFunction: any;
             let recipient: TestForwarderTargetInstance;
+            const fundedAccountPrivateKey: Buffer = Buffer.from(
+                '0c06818f82e04c564290b32ab86b25676731fc34e9a546108bf109194c8e3aae',
+                'hex'
+            );
 
             beforeEach('Setting values', async () => {
-                smartWallet = await CustomSmartWallet.new();
+                const chainId = (await getTestingEnvironment()).chainId;
                 customLogic = await SuccessCustomLogic.new();
-                token = await TestToken.new();
                 recipient = await TestForwarderTarget.new();
                 recipientFunction = recipient.contract.methods
                     .emitMessage('hello')
                     .encodeABI();
+                const smartWalletTemplate = await CustomSmartWallet.new();
+                const factory = await createCustomSmartWalletFactory(
+                    smartWalletTemplate
+                );
+                smartWallet = await createCustomSmartWallet(
+                    worker,
+                    fundedAccount,
+                    factory,
+                    fundedAccountPrivateKey,
+                    chainId,
+                    customLogic.address,
+                    '0x'
+                );
             });
 
             it('Should revert call to directExecute with empty parameter', async () => {
@@ -1155,18 +805,6 @@ contract(
             });
 
             it('Should call successfully the method directExecute through node funded account', async () => {
-                assert.isFalse(await smartWallet.isInitialized());
-
-                await smartWallet.initialize(
-                    fundedAccount,
-                    customLogic.address,
-                    token.address,
-                    worker,
-                    '0',
-                    '400000',
-                    '0x'
-                );
-
                 assert.isTrue(await smartWallet.isInitialized());
                 const initialNonce = await smartWallet.nonce();
 
@@ -1175,6 +813,7 @@ contract(
                     recipientFunction,
                     { from: fundedAccount }
                 );
+
                 assert.equal(
                     (await smartWallet.nonce()).toString(),
                     initialNonce.toString(),

--- a/test/smartwallet/customSmartWallet.test.ts
+++ b/test/smartwallet/customSmartWallet.test.ts
@@ -5,136 +5,29 @@ import {
     TestForwarderTargetInstance,
     CustomSmartWalletFactoryInstance
 } from '../../types/truffle-contracts';
-import chai from 'chai';
+import { use, assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {
-    EIP712TypedData,
-    // @ts-ignore
-    signTypedData_v4,
-    TypedDataUtils
-} from 'eth-sig-util';
 import { BN, bufferToHex, toBuffer, privateToAddress } from 'ethereumjs-util';
 import { expectRevert } from '@openzeppelin/test-helpers';
-import {
-    TypedRequestData,
-    ForwardRequestType,
-    RelayRequest,
-    ForwardRequest,
-    RelayData
-} from '../../dist';
-import { constants } from '../constants';
+import { RelayData } from '../../';
 import {
     generateBytes32,
     getTestingEnvironment,
     containsEvent,
     createCustomSmartWallet,
-    createCustomSmartWalletFactory
+    createCustomSmartWalletFactory,
+    createRequest,
+    signRequest,
+    mintTokens,
+    getTokenBalance
 } from '../utils';
 
-chai.use(chaiAsPromised);
-const assert = chai.assert;
+use(chaiAsPromised);
 
 const CustomSmartWallet = artifacts.require('CustomSmartWallet');
 const SuccessCustomLogic = artifacts.require('SuccessCustomLogic');
 const TestToken = artifacts.require('TestToken');
 const TestForwarderTarget = artifacts.require('TestForwarderTarget');
-
-/**
- * Function to get the actual token balance for an account
- * @param token
- * @param account
- * @returns The account token balance
- */
-async function getTokenBalance(
-    token: TestTokenInstance,
-    account: string
-): Promise<BN> {
-    return await token.balanceOf(account);
-}
-
-/**
- * Function to add tokens to an account
- * @param token
- * @param recipient
- * @param amount
- */
-async function mintTokens(
-    token: TestTokenInstance,
-    recipient: string,
-    amount: string
-): Promise<void> {
-    await token.mint(amount, recipient);
-}
-
-/**
- * Function to sign a transaction
- * @param senderPrivateKey
- * @param relayRequest
- * @param chainId
- * @returns  the signature and suffix data
- */
-function signRequest(
-    senderPrivateKey: Buffer,
-    relayRequest: RelayRequest,
-    chainId: number
-): { signature: string; suffixData: string } {
-    const reqData: EIP712TypedData = new TypedRequestData(
-        chainId,
-        relayRequest.relayData.callForwarder,
-        relayRequest
-    );
-    const signature = signTypedData_v4(senderPrivateKey, { data: reqData });
-    const suffixData = bufferToHex(
-        TypedDataUtils.encodeData(
-            reqData.primaryType,
-            reqData.message,
-            reqData.types
-        ).slice((1 + ForwardRequestType.length) * 32)
-    );
-    return { signature, suffixData };
-}
-
-/**
- *
- * @param request Function to create the basic relay request
- * @param relayData
- * @returns The relay request with basic/default values
- */
-function createRequest(
-    request: Partial<ForwardRequest>,
-    relayData: Partial<RelayData>
-): RelayRequest {
-    const baseRequest: RelayRequest = {
-        request: {
-            relayHub: constants.ZERO_ADDRESS,
-            from: constants.ZERO_ADDRESS,
-            to: constants.ZERO_ADDRESS,
-            value: '0',
-            gas: '1000000',
-            nonce: '0',
-            data: '0x',
-            tokenContract: constants.ZERO_ADDRESS,
-            tokenAmount: '1',
-            tokenGas: '50000'
-        },
-        relayData: {
-            gasPrice: '1',
-            relayWorker: constants.ZERO_ADDRESS,
-            callForwarder: constants.ZERO_ADDRESS,
-            callVerifier: constants.ZERO_ADDRESS
-        }
-    };
-    return {
-        request: {
-            ...baseRequest.request,
-            ...request
-        },
-        relayData: {
-            ...baseRequest.relayData,
-            ...relayData
-        }
-    };
-}
 
 contract(
     'Custom SmartWallet contract - Unit testing on methods isInitialize and initialize',

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -1,12 +1,12 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { BN, bufferToHex, toBuffer, privateToAddress } from 'ethereumjs-util';
+import { expectRevert } from '@openzeppelin/test-helpers';
 import {
     TestTokenInstance,
     SmartWalletInstance,
     TestForwarderTargetInstance
 } from '../../types/truffle-contracts';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import { BN, bufferToHex, toBuffer, privateToAddress } from 'ethereumjs-util';
-import { expectRevert } from '@openzeppelin/test-helpers';
 import { RelayData } from '../../';
 import { constants } from '../constants';
 import {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,15 @@
+import sigUtil, {
+    // @ts-ignore
+    signTypedData_v4,
+    EIP712TypedData,
+    TypedDataUtils
+} from 'eth-sig-util';
+import { bufferToHex, privateToAddress } from 'ethereumjs-util';
+import { soliditySha3Raw } from 'web3-utils';
+import { PrefixedHexString } from 'ethereumjs-tx';
+import ethWallet from 'ethereumjs-wallet';
+import { AccountKeypair } from '@rsksmart/rif-relay-client';
+import { HttpProvider } from 'web3-core';
 import RelayHubConfiguration from '../types/RelayHubConfiguration';
 import {
     SmartWalletFactoryInstance,
@@ -20,18 +32,6 @@ import {
     TypedRequestData
 } from '../';
 import { constants } from './constants';
-import sigUtil, {
-    // @ts-ignore
-    signTypedData_v4,
-    EIP712TypedData,
-    TypedDataUtils
-} from 'eth-sig-util';
-import { bufferToHex, privateToAddress } from 'ethereumjs-util';
-import { soliditySha3Raw } from 'web3-utils';
-import { PrefixedHexString } from 'ethereumjs-tx';
-import ethWallet from 'ethereumjs-wallet';
-import { AccountKeypair } from '@rsksmart/rif-relay-client';
-import { HttpProvider } from 'web3-core';
 
 const RelayHub = artifacts.require('RelayHub');
 


### PR DESCRIPTION
## What

- The problem is related to the fact that the initialize method of the template contract is never called, so a malicious attacker could call it and therefore set a logic address. After doing that, the attacker could call any function and that would lead the logic address to be executed. Potentially the logic address could contain a selfdestruct instruction that would destroy the template contract. If so, the proxies contracts won’t be able to execute any transaction anymore.

- I decided to just initialise the CustomSmartWallet implementation contract in the constructor.


## Why

- By using this approach the CustomSmartWallet initialization is blocked since the deployment to prevent malicious initialisation.


## Refs

- [Jira issue](https://rsklabs.atlassian.net/browse/PP-325)
