### PR TITLE
PP-465: REL-002 - Initialize SmartWallet template

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,5 @@ jobs:
 
             # Performs a clean installation of all dependencies in the `package.json` file
             # For more information, see https://docs.npmjs.com/cli/ci.html
-            - name: Run contract test with truffle
-              run: npm run test:truffle
-
-            # Performs a clean installation of all dependencies in the `package.json` file
-            # For more information, see https://docs.npmjs.com/cli/ci.html
-            - name: Run contract test with waffle
+            - name: Run contract test
               run: npm run test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,5 +44,10 @@ jobs:
 
             # Performs a clean installation of all dependencies in the `package.json` file
             # For more information, see https://docs.npmjs.com/cli/ci.html
-            - name: Run contract test
+            - name: Run contract test with truffle
+              run: npm run test:truffle
+
+            # Performs a clean installation of all dependencies in the `package.json` file
+            # For more information, see https://docs.npmjs.com/cli/ci.html
+            - name: Run contract test with waffle
               run: npm run test

--- a/contracts/factory/SmartWalletFactory.sol
+++ b/contracts/factory/SmartWalletFactory.sol
@@ -288,11 +288,16 @@ contract SmartWalletFactory is ISmartWalletFactory {
 
         require(
             RSKAddrValidator.safeEquals(
-                keccak256(abi.encodePacked(
-                    "\x19\x01",
-                    domainSeparator,
-                    keccak256(_getEncoded(req, suffixData)))
-                ).recover(sig), req.from),"signature mismatch"
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        domainSeparator,
+                        keccak256(_getEncoded(req, suffixData))
+                    )
+                ).recover(sig),
+                req.from
+            ),
+            "Signature mismatch"
         );
     }
 }

--- a/test/factory/smartWalletFactory.test.ts
+++ b/test/factory/smartWalletFactory.test.ts
@@ -212,7 +212,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
             await factory.relayedUserSmartWalletCreation(
                 relayRequest.request,
                 suffixData,
-                worker,
                 signature,
                 {
                     from: worker
@@ -262,7 +261,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
             await factory.relayedUserSmartWalletCreation(
                 relayRequest.request,
                 suffixData,
-                worker,
                 signature,
                 {
                     from: worker
@@ -329,7 +327,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
             await factory.relayedUserSmartWalletCreation(
                 relayRequest.request,
                 suffixData,
-                worker,
                 signature,
                 {
                     from: worker
@@ -370,7 +367,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
-                    worker,
                     signature,
                     {
                         from: worker
@@ -409,7 +405,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
-                    worker,
                     signature,
                     {
                         from: worker
@@ -449,7 +444,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
-                    worker,
                     signature,
                     {
                         from: worker
@@ -489,7 +483,6 @@ contract('SmartWalletFactory', ([worker, otherAccount]) => {
                 factory.relayedUserSmartWalletCreation(
                     relayRequest.request,
                     suffixData,
-                    worker,
                     signature,
                     {
                         from: worker

--- a/test/factory/smartWalletFactory.test.ts
+++ b/test/factory/smartWalletFactory.test.ts
@@ -1,0 +1,503 @@
+import { AccountKeypair } from '@rsksmart/rif-relay-client';
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { ethers } from 'ethers';
+import {
+    SmartWalletFactoryInstance,
+    SmartWalletInstance,
+    TestTokenInstance
+} from '../../types/truffle-contracts';
+import { constants } from '../constants';
+import {
+    createRequest,
+    getGaslessAccount,
+    getTestingEnvironment,
+    getTokenBalance,
+    mintTokens,
+    signRequest
+} from '../utils';
+
+use(chaiAsPromised);
+
+const SmartWallet = artifacts.require('SmartWallet');
+const SmartWalletFactory = artifacts.require('SmartWalletFactory');
+const TestToken = artifacts.require('TestToken');
+
+type createUserSmartWalletParam = {
+    owner: string;
+    recoverer: string;
+    index: string;
+};
+
+/**
+ * Function to get the actual token balance for an account
+ * @param owner.address
+ * @param ownerPrivateKey
+ * @param recoverer
+ * @param logicAddress
+ * @param index
+ * @param initParams
+ * @returns The createUserSmartWallet signed
+ */
+function createUserSmartWalletSignature(
+    ownerPrivateKey: Buffer,
+    object: createUserSmartWalletParam
+): string {
+    const { owner, recoverer, index } = object;
+
+    const toSign: string =
+        web3.utils.soliditySha3(
+            { t: 'bytes2', v: '0x1910' },
+            { t: 'address', v: owner },
+            { t: 'address', v: recoverer },
+            { t: 'uint256', v: index }
+        ) ?? '';
+    const toSignAsBinaryArray = ethers.utils.arrayify(toSign);
+    const signingKey = new ethers.utils.SigningKey(ownerPrivateKey);
+    const signature = signingKey.signDigest(toSignAsBinaryArray);
+    const signatureCollapsed = ethers.utils.joinSignature(signature);
+
+    return signatureCollapsed;
+}
+
+contract('SmartWalletFactory', ([worker, otherAccount]) => {
+    let chainId: number;
+    let factory: SmartWalletFactoryInstance;
+    let owner: AccountKeypair;
+
+    describe('createUserSmartWallet', async () => {
+        const recoverer = constants.ZERO_ADDRESS;
+        const index = '0';
+
+        beforeEach(async () => {
+            owner = await getGaslessAccount();
+            chainId = (await getTestingEnvironment()).chainId;
+            const smartWallet = await SmartWallet.new();
+            factory = await SmartWalletFactory.new(smartWallet.address);
+        });
+
+        it('Should initiate the smart wallet in the expected address', async () => {
+            const smartWalletAddress = await factory.getSmartWalletAddress(
+                owner.address,
+                recoverer,
+                index
+            );
+
+            await expect(SmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
+                `Cannot create instance of SmartWallet; no code at address ${smartWalletAddress}`
+            );
+
+            const signatureCollapsed = createUserSmartWalletSignature(
+                owner.privateKey,
+                {
+                    owner: owner.address,
+                    recoverer,
+                    index
+                }
+            );
+
+            await factory.createUserSmartWallet(
+                owner.address,
+                recoverer,
+                index,
+                signatureCollapsed
+            );
+
+            const smartWallet: SmartWalletInstance = await SmartWallet.at(
+                smartWalletAddress
+            );
+
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
+        });
+
+        it('Should fail with a ZERO owner address parameter', async () => {
+            const signatureCollapsed = createUserSmartWalletSignature(
+                owner.privateKey,
+                {
+                    owner: constants.ZERO_ADDRESS,
+                    recoverer,
+                    index
+                }
+            );
+
+            await expect(
+                factory.createUserSmartWallet(
+                    constants.ZERO_ADDRESS,
+                    recoverer,
+                    index,
+                    signatureCollapsed
+                )
+            ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Invalid signature'
+            );
+        });
+
+        it('Should fail when signature does not match', async () => {
+            const signatureCollapsed = createUserSmartWalletSignature(
+                owner.privateKey,
+                {
+                    owner: owner.address,
+                    recoverer,
+                    index
+                }
+            );
+
+            await expect(
+                factory.createUserSmartWallet(
+                    otherAccount,
+                    recoverer,
+                    index,
+                    signatureCollapsed
+                )
+            ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Invalid signature'
+            );
+        });
+    });
+
+    describe('relayedUserSmartWalletCreation', () => {
+        let smartWalletAddress: string;
+        let token: TestTokenInstance;
+        const logicAddress = constants.ZERO_ADDRESS;
+        const initParams = '0x';
+        const recoverer = constants.ZERO_ADDRESS;
+        const index = '0';
+
+        beforeEach(async () => {
+            chainId = (await getTestingEnvironment()).chainId;
+            const smartWallet = await SmartWallet.new();
+            factory = await SmartWalletFactory.new(smartWallet.address);
+        });
+
+        beforeEach(async () => {
+            token = await TestToken.new();
+            smartWalletAddress = await factory.getSmartWalletAddress(
+                owner.address,
+                recoverer,
+                index
+            );
+        });
+
+        it('Should initialize the smart wallet in the expected address without paying fee', async () => {
+            const initialWorkerBalance = await getTokenBalance(token, worker);
+            expect(initialWorkerBalance.toString()).to.be.equal('0');
+
+            await expect(SmartWallet.at(smartWalletAddress)).to.be.rejectedWith(
+                `Cannot create instance of SmartWallet; no code at address ${smartWalletAddress}`
+            );
+
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '0',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            await factory.relayedUserSmartWalletCreation(
+                relayRequest.request,
+                suffixData,
+                worker,
+                signature,
+                {
+                    from: worker
+                }
+            );
+
+            const smartWallet: SmartWalletInstance = await SmartWallet.at(
+                smartWalletAddress
+            );
+
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
+
+            const finalWorkerBalance = await getTokenBalance(token, worker);
+            await expect(finalWorkerBalance.toString()).to.be.equal('0');
+        });
+
+        it('Should initialize the smart wallet in the expected address paying fee', async () => {
+            const initialWorkerBalance = await getTokenBalance(token, worker);
+            expect(initialWorkerBalance.toString()).to.be.equal('0');
+
+            await mintTokens(token, smartWalletAddress, '1000');
+            const fee = '500';
+
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: fee,
+                    tokenGas: '50000',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            await factory.relayedUserSmartWalletCreation(
+                relayRequest.request,
+                suffixData,
+                worker,
+                signature,
+                {
+                    from: worker
+                }
+            );
+
+            const smartWallet: SmartWalletInstance = await SmartWallet.at(
+                smartWalletAddress
+            );
+
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
+
+            const finalWorkerBalance = await getTokenBalance(token, worker);
+            await expect(finalWorkerBalance.toString()).to.be.equal(fee);
+        });
+
+        it('Should fail with negative token amount', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '-100',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            expect(() =>
+                signRequest(owner.privateKey, relayRequest, chainId)
+            ).to.throw('Supplied uint is negative');
+        });
+
+        it('Should fail with token as ZERO address parameter', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: constants.ZERO_ADDRESS,
+                    tokenAmount: '5000',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            await factory.relayedUserSmartWalletCreation(
+                relayRequest.request,
+                suffixData,
+                worker,
+                signature,
+                {
+                    from: worker
+                }
+            );
+            const smartWallet: SmartWalletInstance = await SmartWallet.at(
+                smartWalletAddress
+            );
+
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
+        });
+
+        it('Should fail when owner does not have funds to pay', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '5000',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            await expect(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    worker,
+                    signature,
+                    {
+                        from: worker
+                    }
+                )
+            ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Unable to initialize SW'
+            );
+        });
+
+        it('Should fail when invalid caller(Not relayHub)', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '5000',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: otherAccount
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            await expect(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    worker,
+                    signature,
+                    {
+                        from: worker
+                    }
+                )
+            ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Invalid caller'
+            );
+        });
+
+        it('Should fail when nonce does not match', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '5000',
+                    tokenGas: '0',
+                    recoverer: recoverer,
+                    index: index,
+                    relayHub: worker,
+                    nonce: '1'
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            await expect(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    worker,
+                    signature,
+                    {
+                        from: worker
+                    }
+                )
+            ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert nonce mismatch'
+            );
+        });
+
+        it('Should fail when signature does not match', async () => {
+            const relayRequest = createRequest(
+                {
+                    from: owner.address,
+                    to: logicAddress,
+                    data: initParams,
+                    tokenContract: token.address,
+                    tokenAmount: '5000',
+                    tokenGas: '0',
+                    index: index,
+                    relayHub: worker
+                },
+                {
+                    callForwarder: factory.address
+                }
+            );
+
+            const { signature, suffixData } = signRequest(
+                owner.privateKey,
+                relayRequest,
+                chainId
+            );
+
+            relayRequest.request.from = otherAccount;
+
+            await expect(
+                factory.relayedUserSmartWalletCreation(
+                    relayRequest.request,
+                    suffixData,
+                    worker,
+                    signature,
+                    {
+                        from: worker
+                    }
+                )
+            ).to.be.rejectedWith(
+                'Returned error: VM Exception while processing transaction: revert Signature mismatch'
+            );
+        });
+    });
+});

--- a/test/relayHub/RelayHub.test.ts
+++ b/test/relayHub/RelayHub.test.ts
@@ -1030,7 +1030,7 @@ contract(
                 );
             });
 
-            it('Should faild a deployRequest if SmartWallet has already been initialized', async () => {
+            it('Should fail a deployRequest if SmartWallet has already been initialized', async () => {
                 await relayHubInstance.stakeForAddress(relayManager, 1000, {
                     value: ether('2'),
                     from: relayOwner
@@ -1044,15 +1044,6 @@ contract(
 
                 const smartWalletTemplate: SmartWalletInstance =
                     await SmartWallet.new();
-                const senderAccount = web3.eth.accounts.create();
-
-                smartWalletTemplate.initialize(
-                    senderAccount.address,
-                    token.address,
-                    relayWorker,
-                    '0',
-                    '400000'
-                );
                 factory = await createSmartWalletFactory(smartWalletTemplate);
 
                 const calculatedAddr = await factory.getSmartWalletAddress(
@@ -1073,7 +1064,7 @@ contract(
                 );
             });
 
-            it('Should faild a deployRequest if Manager is unstaked', async () => {
+            it('Should fail a deployRequest if Manager is unstaked', async () => {
                 await relayHubInstance.stakeForAddress(relayManager, 1000, {
                     value: ether('1'),
                     from: relayOwner

--- a/test/smartwallet/smartWallet.template.test.ts
+++ b/test/smartwallet/smartWallet.template.test.ts
@@ -1,0 +1,38 @@
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { SmartWalletInstance } from '../../types/truffle-contracts';
+import { constants } from '../constants';
+
+use(chaiAsPromised);
+
+const SmartWallet = artifacts.require('SmartWallet');
+
+contract('SmartWallet - template', ([owner]) => {
+    describe('initialize', () => {
+        let smartWallet: SmartWalletInstance;
+
+        beforeEach(async () => {
+            smartWallet = await SmartWallet.new();
+        });
+
+        it('Should be initialized during the deployment', async () => {
+            await expect(smartWallet.isInitialized()).to.eventually.be.true;
+        });
+
+        it('Should verify method initialize fails when contract has already deployed', async () => {
+            const tokenAddress = constants.ZERO_ADDRESS;
+            const recipient = constants.ZERO_ADDRESS;
+
+            await expect(
+                smartWallet.initialize(
+                    owner,
+                    tokenAddress,
+                    recipient,
+                    '0',
+                    '5000'
+                )
+            ).to.be.rejectedWith('already initialized');
+        });
+    });
+});

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -365,7 +365,7 @@ contract(
                     },
                     relayData
                 );
-                
+
                 const { signature, suffixData } = signRequest(
                     senderPrivateKey,
                     relayRequest,

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -365,7 +365,7 @@ contract(
                     },
                     relayData
                 );
-                // relayRequest.relayData.callForwarder = smartWallet.address;
+                
                 const { signature, suffixData } = signRequest(
                     senderPrivateKey,
                     relayRequest,

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -9,7 +9,6 @@ import {
     SmartWalletFactoryInstance
 } from '../../types/truffle-contracts';
 import { RelayData } from '../../';
-import { constants } from '../constants';
 import {
     createRequest,
     createSmartWallet,
@@ -84,7 +83,7 @@ contract(
                         token.address,
                         worker,
                         '0',
-                        '400000',
+                        '400000'
                     ),
                     'already initialized',
                     'Error while validating data'
@@ -111,9 +110,7 @@ contract('SmartWallet contract - Unit testing on method verify', ([worker]) => {
                 privateToAddress(senderPrivateKey)
             ).toLowerCase();
             const smartWalletTemplate = await SmartWallet.new();
-            const factory = await createSmartWalletFactory(
-                smartWalletTemplate
-            );
+            const factory = await createSmartWalletFactory(smartWalletTemplate);
             smartWallet = await createSmartWallet(
                 worker,
                 senderAddress,


### PR DESCRIPTION
## What

- We need to initialize the SmartWallet template to avoid security issues.

## Why

- If not initialized, an attacker could initialize it. Although this doesn't imply any security issue at the moment, it could open the attack surface to some social engineering attacks.
- It's a good practice initializing the contracts

