### PR TITLE
PP473: Replace Ownable with own ownership mechanism

### DIFF
--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -23,9 +23,8 @@ abstract contract Ownable {
      * @dev Initializes the contract setting the deployer as the initial owner.
      */
     constructor () internal {
-        address msgSender = msg.sender;
-        _owner = msgSender;
-        emit OwnershipTransferred(address(0), msgSender);
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), _owner);
     }
 
     /**

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -43,22 +43,10 @@ abstract contract Ownable {
     }
 
     /**
-     * @dev Leaves the contract without owner. It will not be possible to call
-     * `onlyOwner` functions anymore. Can only be called by the current owner.
-     *
-     * NOTE: Renouncing ownership will leave the contract without an owner,
-     * thereby removing any functionality that is only available to the owner.
-     */
-    function renounceOwnership() public virtual onlyOwner {
-        emit OwnershipTransferred(_owner, address(0));
-        _owner = address(0);
-    }
-
-    /**
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      * Can only be called by the current owner.
      */
-    function transferOwnership(address newOwner) public virtual onlyOwner {
+    function transferOwnership(address newOwner) public onlyOwner {
         require(newOwner != address(0), "Owner is the zero address");
         emit OwnershipTransferred(_owner, newOwner);
         _owner = newOwner;

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () internal {
+        address msgSender = msg.sender;
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "Caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/contracts/utils/VersionRegistry.sol
+++ b/contracts/utils/VersionRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.6.12;
 // solhint-disable not-rely-on-time
 
 import "../interfaces/IVersionRegistry.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "../Ownable.sol";
 
 contract VersionRegistry is IVersionRegistry, Ownable {
 

--- a/contracts/verifier/CustomSmartWalletDeployVerifier.sol
+++ b/contracts/verifier/CustomSmartWalletDeployVerifier.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
+import "../Ownable.sol";
 import "../factory/CustomSmartWalletFactory.sol";
 import "../interfaces/IDeployVerifier.sol";
 import "../interfaces/ITokenHandler.sol";

--- a/contracts/verifier/DeployVerifier.sol
+++ b/contracts/verifier/DeployVerifier.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
+import "../Ownable.sol";
 import "../factory/SmartWalletFactory.sol";
 import "../interfaces/IDeployVerifier.sol";
 import "../interfaces/ITokenHandler.sol";

--- a/contracts/verifier/RelayVerifier.sol
+++ b/contracts/verifier/RelayVerifier.sol
@@ -4,8 +4,8 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
+import "../Ownable.sol";
 import "../interfaces/IWalletFactory.sol";
 import "../interfaces/IRelayVerifier.sol";
 import "../interfaces/ITokenHandler.sol";


### PR DESCRIPTION
## What

- Creates an abstract contract called Ownable and replaces all the implementations of Openzeppelin/Ownable

## Why

- The Openzeppelin implementation has not required functionalities that uses extra gas

## Refs

- [PP-473](https://rsklabs.atlassian.net/browse/PP-473)
