### PR TITLE
Remove duplicated packages from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "@openeth/truffle-typings": "0.0.6",
     "@openzeppelin/test-helpers": "^0.5.15",
     "@rsksmart/rif-relay-client": "^0.0.2-alpha.7",
-    "@truffle/contract-schema": "3.3.2",
-    "@truffle/hdwallet-provider": "1.2.4",
     "@trufflesuite/web3-provider-engine": "^15.0.13-1",
     "@types/chai": "^4.2.12",
     "@types/chai-as-promised": "^7.1.3",


### PR DESCRIPTION
## What

- Remove duplicated packages from `devDependencies`

## Why

- The package `"@truffle/hdwallet-provider": "1.2.4",` was outdated, so it was raising the following error:
> "Missing parameter, gasPrice, gas or value"

It has been already [fixed before](https://github.com/rsksmart/rif-relay-contracts/pull/12), but we missed the `devDependency` so the error appeared again.

## Refs

- https://github.com/rsksmart/rif-relay-contracts/pull/12
