### PR TITLE
getAllowedToken task

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ This project is part of the RIF Relay ecosystem. It contains all the smart contr
   - [**Addresses**](#addresses)
 - [**System usage**](#system-usage)
   - [**Allowing tokens**](#allowing-tokens)
-  - [**TestToken Minting**](#testtoken-minting)
+  - [**UtilToken Minting**](#UtilToken-minting)
 - [**Library usage**](#library-usage)
   - [**As a dependency**](#as-a-dependency)
   - [**Development**](#development)
@@ -44,7 +44,7 @@ The project is ready to be used at this point.
 The contracts can be deployed in the following way:
 
 1. Configure the `hardhat.config.ts` file on the root of the project to set your network 
-2. Run `npm run deploy --network <NETWORK_NAME>` 
+2. Run `npm run deploy <NETWORK_NAME>` 
 
 This will start the migration on `<NETWORK_NAME>`; at the end of it you should see a summary with all the contract addresses.
 
@@ -110,12 +110,12 @@ Once the smart contracts are deployed, tokens must be individually allowed to be
 
 1. To allow a specific token, run `npm run allow-tokens <NETWORK_NAME> <TOKEN_ADDRESSES>` where:
     - `<TOKEN_ADDRESSES>` is a comma-separated list of the token addresses to be allowed on the available verifiers
-    - `<NETWORK_NAME>` is an optional parameter for the network name, taken from the `truffle.js` file (default value is `regtest`) **important! This should be the same network name as the one used to deploy the contracts** 
-2. To query allowed tokens run `npm run allowedTokens <NETWORK_NAME>`. This will display them on the console.
+    - `<NETWORK_NAME>` is an optional parameter for the network name, taken from the `hardhat.config.ts` file (default value is `hardhat`) **important! This should be the same network name as the one used to deploy the contracts** 
+2. To query allowed tokens run `npm run allowed-tokens <NETWORK_NAME>`. This will display them on the console.
 
-### TestToken Minting
+### UtilToken Minting
 
-Once the smart contracts are deployed, [TestToken](./contracts/test/tokens/TestToken.sol)s can be minted and transferred by using the related script:
+Once the smart contracts are deployed, [UtilToken](./contracts/utils/UtilToken.sol)s can be minted and transferred by using the related script:
 ```bash
 npx truffle exec --network <network_name> tasks/mint.js --tokenReceiver <0xabc123> --amount <amount_in_wei>
 ```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import '@nomiclabs/hardhat-ethers';
 import { allowTokens } from './scripts/allowTokens';
 import { deploy } from './scripts/deploy';
 import { HardhatUserConfig, task } from 'hardhat/config';
+import { getAllowedTokens } from './scripts/getAllowedTokens';
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -81,10 +82,16 @@ task('deploy', 'Deploys rif-relay contracts to selected network')
   }
 );
 
-task('allow-tokens', 'allows a list of tokens')
+task('allow-tokens', 'Allows a list of tokens')
   .addPositionalParam('tokenlist', 'list of tokens')
   .setAction(async (taskArgs: { tokenlist: string }, hre) => {
     await allowTokens(taskArgs, hre);
+  }
+);
+
+task('allowed-tokens', 'Retrieves a list of allowed tokens')
+  .setAction(async (taskArgs, hre) => {
+    await getAllowedTokens(hre);
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "scripts": {
     "allow-tokens": "hardhat allow-tokens --network",
+    "allowed-tokens": "hardhat allowed-tokens --network",
     "ci:format": "prettier -c contracts/**/*.sol && prettier -c **/*.ts",
     "ci:lint": "solhint 'contracts/**/*.sol' && eslint test --ext .ts ",
     "ci:test": "npm run compile && npm run test",

--- a/scripts/allowTokens.ts
+++ b/scripts/allowTokens.ts
@@ -77,7 +77,7 @@ export const allowTokens = async (
   verifierMap.set('deployVerifier', deployVerifier);
   verifierMap.set('relayVerifier', relayVerifier);
   verifierMap.set('customDeployVerifier', customDeployVerifier);
-  verifierMap.set('customRelayVerifier', customRelayVerifier)
+  verifierMap.set('customRelayVerifier', customRelayVerifier);
 
   for (const tokenAddress of tokenAddresses) {
     for (const [key, verifier] of verifierMap) {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -97,6 +97,9 @@ export const deployContracts = async (
     await customSmartWalletDeployVerifierF.deploy(
       customSmartWalletFactoryAddress
     );
+  const { address: customRelayVerifierAddress } = await relayVerifierF.deploy(
+    smartWalletFactoryAddress
+  );
 
   const { address: versionRegistryAddress } =
     await versionRegistryFactory.deploy();
@@ -117,6 +120,7 @@ export const deployContracts = async (
     CustomSmartWallet: customSmartWalletAddress,
     CustomSmartWalletFactory: customSmartWalletFactoryAddress,
     CustomSmartWalletDeployVerifier: customDeployVerifierAddress,
+    CustomSmartWalletRelayVerifier: customRelayVerifierAddress,
     UtilToken: utilTokenAddress,
     VersionRegistry: versionRegistryAddress,
   };

--- a/scripts/getAllowedTokens.ts
+++ b/scripts/getAllowedTokens.ts
@@ -1,13 +1,9 @@
-import { ContractTransaction } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { getExistingConfig } from './deploy';
 
-export const allowTokens = async (
-  taskArgs: { tokenlist: string },
+export const getAllowedTokens = async (
   hre: HardhatRuntimeEnvironment
 ) => {
-  const tokenAddresses = taskArgs.tokenlist.split(',');
-
   const { ethers, network } = hre;
 
   if (!network) {
@@ -72,24 +68,23 @@ export const allowTokens = async (
 
   const verifierMap: Map<
     string,
-    { acceptToken: (tokenAddress: string) => Promise<ContractTransaction> }
+    { getAcceptedTokens: () => Promise<string[]> }
   > = new Map();
   verifierMap.set('deployVerifier', deployVerifier);
   verifierMap.set('relayVerifier', relayVerifier);
   verifierMap.set('customDeployVerifier', customDeployVerifier);
   verifierMap.set('customRelayVerifier', customRelayVerifier)
 
-  for (const tokenAddress of tokenAddresses) {
-    for (const [key, verifier] of verifierMap) {
-      try {
-        await verifier.acceptToken(tokenAddress);
-      } catch (error) {
-        console.error(
-          `Error adding token with address ${tokenAddress} to allowed tokens on ${key}`
-        );
-        throw error;
-      }
+
+  for (const [key, verifier] of verifierMap) {
+    try {
+      const allowedTokens = await verifier.getAcceptedTokens();
+      console.log(key, allowedTokens)
+    } catch (error) {
+      console.error(
+        `Error getting allowed tokens for ${key}`
+      );
+      throw error;
     }
   }
-  console.log('Tokens allowed successfully!');
 };

--- a/scripts/getAllowedTokens.ts
+++ b/scripts/getAllowedTokens.ts
@@ -1,9 +1,7 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { getExistingConfig } from './deploy';
 
-export const getAllowedTokens = async (
-  hre: HardhatRuntimeEnvironment
-) => {
+export const getAllowedTokens = async (hre: HardhatRuntimeEnvironment) => {
   const { ethers, network } = hre;
 
   if (!network) {
@@ -73,17 +71,14 @@ export const getAllowedTokens = async (
   verifierMap.set('deployVerifier', deployVerifier);
   verifierMap.set('relayVerifier', relayVerifier);
   verifierMap.set('customDeployVerifier', customDeployVerifier);
-  verifierMap.set('customRelayVerifier', customRelayVerifier)
-
+  verifierMap.set('customRelayVerifier', customRelayVerifier);
 
   for (const [key, verifier] of verifierMap) {
     try {
       const allowedTokens = await verifier.getAcceptedTokens();
-      console.log(key, allowedTokens)
+      console.log(key, allowedTokens);
     } catch (error) {
-      console.error(
-        `Error getting allowed tokens for ${key}`
-      );
+      console.error(`Error getting allowed tokens for ${key}`);
       throw error;
     }
   }

--- a/test/scripts/deploy.test.ts
+++ b/test/scripts/deploy.test.ts
@@ -40,6 +40,7 @@ describe('Deploy Script', function () {
         'CustomSmartWallet',
         'CustomSmartWalletFactory',
         'CustomSmartWalletDeployVerifier',
+        'CustomSmartWalletRelayVerifier',
         'VersionRegistry',
         'UtilToken'
       );
@@ -70,6 +71,8 @@ describe('Deploy Script', function () {
       CustomSmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
       CustomSmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
       CustomSmartWalletDeployVerifier:
+        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+      CustomSmartWalletRelayVerifier:
         '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
       VersionRegistry: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
       UtilToken: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',

--- a/test/scripts/getAllowedTokens.test.ts
+++ b/test/scripts/getAllowedTokens.test.ts
@@ -6,15 +6,13 @@ import * as hre from 'hardhat';
 import { ethers } from 'hardhat';
 import sinon from 'sinon';
 import {
-  allowTokens
-} from '../../scripts/allowTokens';
+  getAllowedTokens
+} from '../../scripts/getAllowedTokens';
 
 use(chaiAsPromised);
 
-describe('Allow Tokens Script', function () {
-  describe('allowTokens', function () {
-    const taskArgs = { tokenlist: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7' };
-
+describe('Get Allowed Tokens Script', function () {
+  describe('getAllowedTokens', function () {
     const contractAddresses = {
       Penalizer: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
       RelayHub: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
@@ -48,20 +46,20 @@ describe('Allow Tokens Script', function () {
       sinon.restore();
     });
 
-    it('should allow a list of tokens', async function () {
+    it('should get several lists of allowed tokens succesfully', async function () {
       const stubContract = sinon.createStubInstance(Contract);
-      stubContract.acceptToken = () => undefined;
+      stubContract.getAcceptedTokens = () => undefined;
       sinon.stub(ethers, 'getContractAt').resolves(stubContract);
-      await expect(allowTokens(taskArgs, hre)).to.not.be.rejected;
+      await expect(getAllowedTokens(hre)).to.not.be.rejected;
     });
 
-    it('should throw error and print it if token cannot be allowed', async function () {
+    it('should throw error and print it if error while getting allowed tokens', async function () {
       const stubContract = sinon.createStubInstance(Contract);
       stubContract.acceptToken = () => {
         throw new Error();
       };
       sinon.stub(ethers, 'getContractAt').resolves(stubContract);
-      await expect(allowTokens(taskArgs, hre)).to.be.rejected;
+      await expect(getAllowedTokens(hre)).to.be.rejected;
     });
   });
 });

--- a/utils/scripts/types.ts
+++ b/utils/scripts/types.ts
@@ -13,10 +13,10 @@ const factoryList = {
   
   export type ContractName = FactoryName extends `${infer Prefix}__factory`
     ? Prefix
-    : never;
+    : never ;
   
   export type ContractAddresses = {
-    [key in ContractName]: string | undefined;
+    [key in (ContractName | 'CustomSmartWalletRelayVerifier')]: string | undefined;
   };
   
   export type NetworkConfig = {


### PR DESCRIPTION
## What

- recreates the allowedTokens script in ethers/hardhat
- fix: missing customSmartWalletRelayVerifier contract on all scripts

## Why

- ethers migration

## Refs

- (optional: include links to other issues, PRs, tickets, etc)
