### PR TITLE
PP-478: Rewrite collector tests

### DIFF
--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -1,406 +1,371 @@
-// import { expect, use } from 'chai';
-// import Collector from '../build/contracts/Collector.json';
-// import TestToken from '../build/contracts/TestToken.json';
-// import {
-//     deployContract,
-//     loadFixture,
-//     MockProvider,
-//     solidity
-// } from 'ethereum-waffle';
-// import { Wallet } from '@ethersproject/wallet';
-
-// use(solidity);
-
-// const PARTNER_SHARES = [20, 30, 40, 10];
-// const NUMBER_OF_PARTNERS = PARTNER_SHARES.length;
-
-// type Partner = {
-//     beneficiary: string;
-//     share: number;
-// };
-
-// async function buildPartners(partnerWallets: Wallet[], shares: number[]) {
-//     return await Promise.all(
-//         partnerWallets.map(async (wallet, index) => {
-//             const partner: Partner = {
-//                 beneficiary: await wallet.getAddress(),
-//                 share: shares[index]
-//             };
-//             return partner;
-//         })
-//     );
-// }
-
-// async function prepareAllFixture(wallets: Wallet[]) {
-//     const [
-//         owner,
-//         remainder,
-//         partner1,
-//         partner2,
-//         partner3,
-//         partner4,
-//         utilWallet
-//     ] = wallets;
-
-//     const testToken = await deployContract(owner, TestToken);
-//     const partners = await buildPartners(
-//         [partner1, partner2, partner3, partner4],
-//         PARTNER_SHARES
-//     );
-
-//     const collector = await deployContract(owner, Collector, [
-//         owner.address,
-//         testToken.address,
-//         partners,
-//         remainder.address
-//     ]);
-
-//     return { collector, testToken, partners, remainder, utilWallet };
-// }
-
-// describe('Collector', () => {
-//     describe('deployment', () => {
-//         it('Should deploy with owner, token and revenue partners', async () => {
-//             const { collector } = await loadFixture(prepareAllFixture);
-//             expect(collector);
-//         });
-
-//         it('Should not let deploy with invalid shares', async () => {
-//             const [owner, remainder, partner1, partner2, partner3, partner4] =
-//                 new MockProvider().getWallets();
-
-//             const testToken = await deployContract(owner, TestToken);
-
-//             const partners = await buildPartners(
-//                 [partner1, partner2, partner3, partner4],
-//                 [25, 25, 25, 26]
-//             );
-
-//             await expect(
-//                 deployContract(owner, Collector, [
-//                     owner.address,
-//                     testToken.address,
-//                     partners,
-//                     remainder.address
-//                 ])
-//             ).to.be.revertedWith('Shares must add up to 100%');
-//         });
-
-//         it('Should not let deploy if the array of partners is empty', async () => {
-//             const [owner, remainder] = new MockProvider().getWallets();
-
-//             const testToken = await deployContract(owner, TestToken);
-
-//             const partners: Wallet[] = [];
-
-//             await expect(
-//                 deployContract(owner, Collector, [
-//                     owner.address,
-//                     testToken.address,
-//                     partners,
-//                     remainder.address
-//                 ])
-//             ).to.be.revertedWith('Shares must add up to 100%');
-//         });
-
-//         it('Should not let deploy if a share is 0', async () => {
-//             const [owner, remainder, partner1, partner2, partner3, partner4] =
-//                 new MockProvider().getWallets();
-
-//             const testToken = await deployContract(owner, TestToken);
-
-//             const partners = await buildPartners(
-//                 [partner1, partner2, partner3, partner4],
-//                 [30, 30, 0, 40]
-//             );
-
-//             await expect(
-//                 deployContract(owner, Collector, [
-//                     owner.address,
-//                     testToken.address,
-//                     partners,
-//                     remainder.address
-//                 ])
-//             ).to.be.revertedWith('0 is not a valid share');
-//         });
-//     });
-
-//     describe('updateShares', () => {
-//         it('Should update shares and partners when token balance is zero', async () => {
-//             const { collector } = await loadFixture(prepareAllFixture);
-//             const newPartners = await buildPartners(
-//                 new MockProvider().getWallets().slice(0, NUMBER_OF_PARTNERS),
-//                 PARTNER_SHARES
-//             );
-
-//             await collector.updateShares(newPartners);
-//             expect('updateShares').to.be.calledOnContract(collector);
-//         });
-
-//         it('Should update shares and partners when token balance is a remainder amount', async () => {
-//             const { collector, testToken } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(3, collector.address);
-
-//             const newPartners = await buildPartners(
-//                 new MockProvider().getWallets().slice(0, NUMBER_OF_PARTNERS),
-//                 PARTNER_SHARES
-//             );
-
-//             await collector.updateShares(newPartners);
-//             expect('updateShares').to.be.calledOnContract(collector);
-//         });
-
-//         it('Should fail when token balance is grater than a remainder', async () => {
-//             const { collector, testToken } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(100, collector.address);
-//             const newPartners = await buildPartners(
-//                 new MockProvider().getWallets().slice(0, NUMBER_OF_PARTNERS),
-//                 PARTNER_SHARES
-//             );
-
-//             await expect(
-//                 collector.updateShares(newPartners)
-//             ).to.be.revertedWith('There is balance to share');
-//         });
-
-//         it('Should fail when is called by an address that is not the owner', async () => {
-//             const { collector, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-//             const externallyLinkedCollector = collector.connect(
-//                 utilWallet.address
-//             );
-//             const newPartners = await buildPartners(
-//                 new MockProvider().getWallets().slice(0, NUMBER_OF_PARTNERS),
-//                 PARTNER_SHARES
-//             );
-
-//             await expect(
-//                 externallyLinkedCollector.updateShares(newPartners)
-//             ).to.be.revertedWith('Only owner can call this');
-//         });
-
-//         it('Should fail if the shares does not sum up to 100', async () => {
-//             const { collector } = await loadFixture(prepareAllFixture);
-
-//             const newPartners = await buildPartners(
-//                 new MockProvider().getWallets().slice(0, NUMBER_OF_PARTNERS),
-//                 [25, 25, 24, 25]
-//             );
-
-//             await expect(
-//                 collector.updateShares(newPartners)
-//             ).to.be.revertedWith('Shares must add up to 100%');
-//         });
-
-//         it('Should fail if a share is 0', async () => {
-//             const { collector } = await loadFixture(prepareAllFixture);
-
-//             const newPartners = await buildPartners(
-//                 new MockProvider().getWallets().slice(0, NUMBER_OF_PARTNERS),
-//                 [50, 25, 25, 0]
-//             );
-
-//             await expect(
-//                 collector.updateShares(newPartners)
-//             ).to.be.revertedWith('0 is not a valid share');
-//         });
-//     });
-
-//     describe('updateRemainderAddress', () => {
-//         it('Should update remainder address when token balance is zero', async () => {
-//             const { collector, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await collector.updateRemainderAddress(utilWallet.address);
-//             expect('updateRemainderAddress').to.be.calledOnContract(collector);
-//         });
-
-//         it('Should update remainder when token balance is a remainder and should withdraw remainder', async () => {
-//             const { collector, testToken, remainder, utilWallet } =
-//                 await loadFixture(prepareAllFixture);
-//             await testToken.mint(2, collector.address);
-
-//             await collector.updateRemainderAddress(utilWallet.address);
-
-//             expect(
-//                 await testToken.balanceOf(collector.address),
-//                 'The balance of collector'
-//             ).to.equal(0);
-//             expect(
-//                 await testToken.balanceOf(remainder.address),
-//                 'The balance of remainder'
-//             ).to.equal(2);
-//         });
-
-//         it('Should withdraw when the remainders address sent is the same as the current one', async () => {
-//             const { collector, testToken, remainder } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(3, collector.address);
-
-//             await collector.updateRemainderAddress(remainder.address);
-
-//             expect(
-//                 await testToken.balanceOf(collector.address),
-//                 'The balance of collector'
-//             ).to.equal(0);
-//             expect(
-//                 await testToken.balanceOf(remainder.address),
-//                 'The balance of remainder'
-//             ).to.equal(3);
-//         });
-
-//         it('Should fail when token balance > = remainder', async () => {
-//             const { collector, testToken, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(4, collector.address);
-
-//             await expect(
-//                 collector.updateRemainderAddress(utilWallet.address)
-//             ).to.be.revertedWith('There is balance to share');
-//         });
-
-//         it('Should fail when is called by an address that is not the owner', async () => {
-//             const { collector, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-//             const externallyLinkedCollector = collector.connect(
-//                 utilWallet.address
-//             );
-
-//             await expect(
-//                 externallyLinkedCollector.updateRemainderAddress(
-//                     utilWallet.address
-//                 )
-//             ).to.be.revertedWith('Only owner can call this');
-//         });
-//     });
-
-//     describe('getBalance', () => {
-//         it('Should return 0 if the contract has been just deployed', async () => {
-//             const { collector } = await loadFixture(prepareAllFixture);
-
-//             await expect(await collector.getBalance()).to.equal(0);
-//         });
-
-//         it('Should return 100 after that value has been minted', async () => {
-//             const { collector, testToken } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(100, collector.address);
-
-//             await expect(await collector.getBalance()).to.equal(100);
-//         });
-//     });
-
-//     describe('withdraw', () => {
-//         it('Should withdraw', async () => {
-//             const { collector, testToken, partners } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(100, collector.address);
-//             await collector.withdraw();
-//             expect(
-//                 await testToken.balanceOf(partners[0].beneficiary),
-//                 'Partner[0] balance'
-//             ).to.equal(PARTNER_SHARES[0]);
-
-//             expect(
-//                 await testToken.balanceOf(partners[1].beneficiary),
-//                 'Partner[1] balance'
-//             ).to.equal(PARTNER_SHARES[1]);
-
-//             expect(
-//                 await testToken.balanceOf(partners[2].beneficiary),
-//                 'Partner[2] balance'
-//             ).to.equal(PARTNER_SHARES[2]);
-
-//             expect(
-//                 await testToken.balanceOf(partners[3].beneficiary),
-//                 'Partner[3] balance'
-//             ).to.equal(PARTNER_SHARES[3]);
-
-//             expect(
-//                 await testToken.balanceOf(collector.address),
-//                 'Balance of the collector'
-//             ).to.equal(0);
-//         });
-
-//         it('Should not fail if the revenue to share is equal to the number of partners', async () => {
-//             const { collector, testToken } = await loadFixture(
-//                 prepareAllFixture
-//             );
-//             // We assume the current balance of the collector to be
-//             // equal to the number of partners
-//             await testToken.mint(NUMBER_OF_PARTNERS, collector.address);
-
-//             await collector.withdraw();
-//             expect(
-//                 await testToken.balanceOf(collector.address),
-//                 'Balance of the collector'
-//             ).to.be.equal('2');
-//         });
-
-//         it('Should fail when no revenue to share', async () => {
-//             const { collector, testToken } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await testToken.mint(1, collector.address);
-//             await expect(collector.withdraw()).to.be.revertedWith(
-//                 'Not enough balance to split'
-//             );
-//         });
-
-//         it('Should fail when is called by an address that is not the owner', async () => {
-//             const { collector, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-//             const externallyLinkedCollector = collector.connect(
-//                 utilWallet.address
-//             );
-
-//             await expect(
-//                 externallyLinkedCollector.withdraw()
-//             ).to.be.revertedWith('Only owner can call this');
-//         });
-//     });
-
-//     describe('transferOwnership', () => {
-//         it('Should transfer ownership', async () => {
-//             const { collector, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-
-//             await collector.transferOwnership(utilWallet.address);
-
-//             expect(await collector.owner()).to.be.equal(utilWallet.address);
-//         });
-
-//         it('Should fail when is called by an address that is not the owner', async () => {
-//             const { collector, utilWallet } = await loadFixture(
-//                 prepareAllFixture
-//             );
-//             const externallyLinkedCollector = collector.connect(
-//                 utilWallet.address
-//             );
-
-//             await expect(
-//                 externallyLinkedCollector.transferOwnership(utilWallet.address)
-//             ).to.be.revertedWith('Only owner can call this');
-//         });
-//     });
-// });
+import { smock, FakeContract, MockContractFactory, MockContract } from '@defi-wonderland/smock';
+import chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import { ethers as hardhat } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { Collector__factory } from 'typechain-types';
+import {Collector} from 'typechain-types';
+
+chai.use(smock.matchers);
+chai.use(chaiAsPromised);
+
+const expect = chai.expect;
+
+const PARTNER_SHARES = [20, 30, 40, 10];
+const NUMBER_OF_PARTNERS = PARTNER_SHARES.length;
+
+type Partner = {
+    beneficiary: string;
+    share: number;
+};
+
+async function buildPartners(partnerWallets: SignerWithAddress[], shares: number[]) {
+    return await Promise.all(
+        partnerWallets.map(async (wallet, index) => {
+            const partner: Partner = {
+                beneficiary: await wallet.getAddress(),
+                share: shares[index]
+            };
+
+            return partner;
+        })
+    );
+}
+
+describe('Collector', function(){
+    let owner: SignerWithAddress;
+    let collectorFactory: MockContractFactory<Collector__factory>;
+    let fakeToken: FakeContract;
+    let partners: Partner[];
+    let remainderDestination: SignerWithAddress;
+    let partner1: SignerWithAddress;
+    let partner2: SignerWithAddress;
+    let partner3: SignerWithAddress;
+    let partner4: SignerWithAddress;
+    let collector: MockContract<Collector>;
+
+    async function deployCollector(){
+        partners = await buildPartners([partner1, partner2, partner3, partner4], PARTNER_SHARES);
+    
+        collector = await collectorFactory.deploy(
+            owner.address,
+            fakeToken.address,
+            partners,
+            remainderDestination.address
+        );
+    }
+
+    beforeEach(async function(){
+        [owner, partner1, partner2, partner3, partner4, remainderDestination] = await hardhat.getSigners()
+
+        fakeToken = await smock.fake('ERC20');
+
+        collectorFactory = await smock.mock<Collector__factory>('Collector');
+    });
+
+    describe('constructor()', function(){
+        it('Should deploy a Collector', async function(){
+            partners = await buildPartners([partner1, partner2, partner3, partner4], PARTNER_SHARES);
+            
+            const collector = await collectorFactory.deploy(
+                owner.address,
+                fakeToken.address,
+                partners,
+                remainderDestination.address
+            );
+
+            expect(await collector.owner(), 'Failed to set the owner').to.be.a.properAddress;
+            expect(await collector.token(), 'Failed to set the token').not.to.be.null;
+        });
+
+        it('Should not let deploy with invalid shares', async function()  {
+            const partners = await buildPartners(
+                [partner1, partner2, partner3, partner4],
+                [25, 25, 25, 26]
+            );
+
+            await expect(
+                collectorFactory.deploy(
+                    owner.address,
+                    fakeToken.address,
+                    partners,
+                    remainderDestination.address
+                )
+            ).to.be.revertedWith('Shares must add up to 100%');
+        });
+
+        it('Should not let deploy if the array of partners is empty', async function()  {
+            const partners: Partner[] = [];
+
+            await expect(
+                collectorFactory.deploy(
+                    owner.address,
+                    fakeToken.address,
+                    partners,
+                    remainderDestination.address
+                )
+            ).to.be.revertedWith('Shares must add up to 100%');
+        });
+        
+        it('Should not let deploy if a share is 0', async function () {
+            const partners = await buildPartners(
+                [partner1, partner2, partner3, partner4],
+                [30, 30, 0, 40]
+            );
+
+            await expect(
+                collectorFactory.deploy(
+                    owner.address,
+                    fakeToken.address,
+                    partners,
+                    remainderDestination.address
+                )
+            ).to.be.revertedWith('0 is not a valid share');
+        });
+    });
+
+    describe('updateShares', function (){
+        beforeEach(async function(){
+            await deployCollector();
+        });
+
+        it('Should update shares and partners when token balance is zero', async function() {
+            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
+
+            const newPartners = await buildPartners(
+                [newPartner1, newPartner2, newPartner3, newPartner4],
+                PARTNER_SHARES
+            );
+
+            await collector.updateShares(newPartners);
+
+            expect(collector.updateShares).to.have.been.called;
+        });
+
+        it('Should update shares and partners when token balance is a remainder amount', async function() {
+            fakeToken.balanceOf.returns(3);
+
+            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
+
+            const newPartners = await buildPartners(
+                [newPartner1, newPartner2, newPartner3, newPartner4],
+                PARTNER_SHARES
+            );
+
+            await collector.updateShares(newPartners);            
+
+            expect(collector.updateShares).to.have.been.called;
+        });
+
+        it('Should fail when token balance is grater than a remainder', async function() {
+            fakeToken.balanceOf.returns(5);
+
+            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
+
+            const newPartners = await buildPartners(
+                [newPartner1, newPartner2, newPartner3, newPartner4],
+                PARTNER_SHARES
+            );          
+
+            await expect(
+                collector.updateShares(newPartners)
+            ).to.be.revertedWith('There is balance to share');
+        });
+
+        it('Should fail when is called by an account different than the owner', async function() {
+            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4, notTheOwner ] = await hardhat.getSigners();
+
+            const newPartners = await buildPartners(
+                [newPartner1, newPartner2, newPartner3, newPartner4],
+                PARTNER_SHARES
+            );
+
+            await expect(
+                collector.connect(notTheOwner).updateShares(newPartners)
+            ).to.be.revertedWith('Only owner can call this');
+        });
+
+        it('Should fail if the shares does not sum up to 100', async function() {
+            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
+
+            const newPartners = await buildPartners(
+                [newPartner1, newPartner2, newPartner3, newPartner4],
+                [25, 25, 25, 26]
+            );         
+
+            await expect(
+                collector.updateShares(newPartners)
+            ).to.be.revertedWith('Shares must add up to 100%');
+        });
+
+        it('Should fail if a share is 0', async function() {
+            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
+
+            const newPartners = await buildPartners(
+                [newPartner1, newPartner2, newPartner3, newPartner4],
+                [30, 30, 40, 0]
+            );         
+
+            await expect(
+                collector.updateShares(newPartners)
+            ).to.be.revertedWith('0 is not a valid share');
+        });
+    }); 
+
+    describe('updateRemainderAddress', function() {
+        beforeEach(async function(){
+            await deployCollector();
+        });
+
+        it('Should update remainder address when token balance is zero', async function() {
+            const[,,,,,, newReminderDestination] = await hardhat.getSigners();
+
+            await collector.updateRemainderAddress(newReminderDestination.address);
+
+            expect(collector.updateRemainderAddress).to.have.been.called;
+        });
+
+        it('Should update remainder when token balance is a remainder and should withdraw remainder', async function() {
+            fakeToken.balanceOf.returns(3);
+
+            const[,,,,,, newRemainderDestination] = await hardhat.getSigners();
+
+            await collector.updateRemainderAddress(newRemainderDestination.address);
+
+            expect(
+                fakeToken.transfer
+            ).to.have.been.calledWith(remainderDestination.address, 3);
+        });
+
+        it('Should withdraw when the remainders address sent is the same as the current one', async function() {
+            fakeToken.balanceOf.returns(3);
+
+            await collector.updateRemainderAddress(remainderDestination.address);
+
+            expect(
+                fakeToken.transfer
+            ).to.have.been.calledWith(remainderDestination.address, 3);
+        });
+
+        it('Should fail when token balance > = remainder', async function() {
+            fakeToken.balanceOf.returns(5);
+
+            const[,,,,,, newRemainderDestination] = await hardhat.getSigners();
+
+            await expect(
+                collector.updateRemainderAddress(newRemainderDestination.address)
+            ).to.be.revertedWith('There is balance to share');
+        });
+
+        it('Should fail when is called by an address that is not the owner', async function() {
+            fakeToken.balanceOf.returns(5);
+
+            const[,,,,,, newRemainderDestination, notTheOwner] = await hardhat.getSigners();
+
+            await expect(
+                collector.connect(notTheOwner).updateRemainderAddress(newRemainderDestination.address)
+            ).to.be.revertedWith('Only owner can call this');
+        });
+    });
+
+    describe('getBalance()', function() {
+        beforeEach(async function(){
+            await deployCollector();
+        });
+
+        it('Should return 0 if the contract has been just deployed', async function() {
+            fakeToken.balanceOf.returns(0);
+
+            expect(await collector.getBalance()).to.equal(0);
+        });
+
+        it('Should return 100 after that value has been minted', async function() {
+            fakeToken.balanceOf.returns(100);
+
+            expect(await collector.getBalance()).to.equal(100);
+        });
+    });
+
+    describe('withdraw', function() {
+        beforeEach(async function(){
+            await deployCollector();
+        });
+
+        it('Should withdraw', async function() {
+            fakeToken.balanceOf.returns(100);
+            await collector.withdraw();
+
+            expect(
+                fakeToken.transfer,
+                'Partner[0] balance'
+            ).to.have.been.calledWith(partners[0].beneficiary, PARTNER_SHARES[0]);
+
+            expect(
+                fakeToken.transfer,
+                'Partner[1] balance'
+            ).to.have.been.calledWith(partners[1].beneficiary, PARTNER_SHARES[1]);
+
+            expect(
+                fakeToken.transfer,
+                'Partner[2] balance'
+            ).to.have.been.calledWith(partners[2].beneficiary, PARTNER_SHARES[2]);
+
+            expect(
+                fakeToken.transfer,
+                'Partner[3] balance'
+            ).to.have.been.calledWith(partners[3].beneficiary, PARTNER_SHARES[3]);
+        });
+
+        it('Should not fail if the revenue to share is equal to the number of partners', async function() {
+            // We assume the current balance of the collector to be
+            // equal to the number of partners
+            fakeToken.balanceOf.returns(NUMBER_OF_PARTNERS);
+
+            await collector.withdraw();
+
+            expect(
+                fakeToken.transfer
+            ).to.have.callCount(4);
+        });
+
+        it('Should fail when no revenue to share', async function() {
+            fakeToken.balanceOf.returns(NUMBER_OF_PARTNERS - 1);
+
+            await expect(
+                collector.withdraw()
+            ).to.be.revertedWith('Not enough balance to split');
+        });
+
+        it('Should fail when is called by an address that is not the owner', async function() {
+            fakeToken.balanceOf.returns(100);
+
+            const[,,,,,, notTheOwner] = await hardhat.getSigners();
+
+            await expect(
+                collector.connect(notTheOwner).withdraw()
+            ).to.be.revertedWith('Only owner can call this');
+        });
+    });
+
+    describe('transferOwnership', function() {
+        beforeEach(async function(){
+            await deployCollector();
+        });
+
+        it('Should transfer ownership', async function() {
+            const[,,,,,, newOwner] = await hardhat.getSigners();
+
+            await collector.transferOwnership(newOwner.address);
+
+            expect(await collector.owner()).to.be.equal(newOwner.address);
+        });
+
+        it('Should fail when is called by an address that is not the owner', async function() {
+            const[,,,,,, newOwner, notTheOwner] = await hardhat.getSigners();
+
+            await expect(
+                collector.connect(notTheOwner).transferOwnership(newOwner.address)
+            ).to.be.revertedWith('Only owner can call this');
+        });
+    });
+});

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -1,10 +1,15 @@
-import { smock, FakeContract, MockContractFactory, MockContract } from '@defi-wonderland/smock';
+import {
+  smock,
+  FakeContract,
+  MockContractFactory,
+  MockContract,
+} from '@defi-wonderland/smock';
 import chaiAsPromised from 'chai-as-promised';
 import chai from 'chai';
 import { ethers as hardhat } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { Collector__factory } from 'typechain-types';
-import {Collector} from 'typechain-types';
+import { Collector } from 'typechain-types';
 
 chai.use(smock.matchers);
 chai.use(chaiAsPromised);
@@ -15,357 +20,388 @@ const PARTNER_SHARES = [20, 30, 40, 10];
 const NUMBER_OF_PARTNERS = PARTNER_SHARES.length;
 
 type Partner = {
-    beneficiary: string;
-    share: number;
+  beneficiary: string;
+  share: number;
 };
 
-async function buildPartners(partnerWallets: SignerWithAddress[], shares: number[]) {
-    return await Promise.all(
-        partnerWallets.map(async (wallet, index) => {
-            const partner: Partner = {
-                beneficiary: await wallet.getAddress(),
-                share: shares[index]
-            };
+async function buildPartners(
+  partnerWallets: SignerWithAddress[],
+  shares: number[]
+) {
+  return await Promise.all(
+    partnerWallets.map(async (wallet, index) => {
+      const partner: Partner = {
+        beneficiary: await wallet.getAddress(),
+        share: shares[index],
+      };
 
-            return partner;
-        })
-    );
+      return partner;
+    })
+  );
 }
 
-describe('Collector', function(){
-    let owner: SignerWithAddress;
-    let collectorFactory: MockContractFactory<Collector__factory>;
-    let fakeToken: FakeContract;
-    let partners: Partner[];
-    let remainderDestination: SignerWithAddress;
-    let partner1: SignerWithAddress;
-    let partner2: SignerWithAddress;
-    let partner3: SignerWithAddress;
-    let partner4: SignerWithAddress;
-    let collector: MockContract<Collector>;
+describe('Collector', function () {
+  let owner: SignerWithAddress;
+  let collectorFactory: MockContractFactory<Collector__factory>;
+  let fakeToken: FakeContract;
+  let partners: Partner[];
+  let remainderDestination: SignerWithAddress;
+  let partner1: SignerWithAddress;
+  let partner2: SignerWithAddress;
+  let partner3: SignerWithAddress;
+  let partner4: SignerWithAddress;
+  let collector: MockContract<Collector>;
 
-    async function deployCollector(){
-        partners = await buildPartners([partner1, partner2, partner3, partner4], PARTNER_SHARES);
-    
-        collector = await collectorFactory.deploy(
-            owner.address,
-            fakeToken.address,
-            partners,
-            remainderDestination.address
-        );
-    }
+  async function deployCollector() {
+    partners = await buildPartners(
+      [partner1, partner2, partner3, partner4],
+      PARTNER_SHARES
+    );
 
-    beforeEach(async function(){
-        [owner, partner1, partner2, partner3, partner4, remainderDestination] = await hardhat.getSigners()
+    collector = await collectorFactory.deploy(
+      owner.address,
+      fakeToken.address,
+      partners,
+      remainderDestination.address
+    );
+  }
 
-        fakeToken = await smock.fake('ERC20');
+  beforeEach(async function () {
+    [owner, partner1, partner2, partner3, partner4, remainderDestination] =
+      await hardhat.getSigners();
 
-        collectorFactory = await smock.mock<Collector__factory>('Collector');
+    fakeToken = await smock.fake('ERC20');
+
+    collectorFactory = await smock.mock<Collector__factory>('Collector');
+  });
+
+  describe('constructor()', function () {
+    it('Should deploy a Collector', async function () {
+      partners = await buildPartners(
+        [partner1, partner2, partner3, partner4],
+        PARTNER_SHARES
+      );
+
+      const collector = await collectorFactory.deploy(
+        owner.address,
+        fakeToken.address,
+        partners,
+        remainderDestination.address
+      );
+
+      expect(await collector.owner(), 'Failed to set the owner').to.be.a
+        .properAddress;
+      expect(await collector.token(), 'Failed to set the token').not.to.be.null;
     });
 
-    describe('constructor()', function(){
-        it('Should deploy a Collector', async function(){
-            partners = await buildPartners([partner1, partner2, partner3, partner4], PARTNER_SHARES);
-            
-            const collector = await collectorFactory.deploy(
-                owner.address,
-                fakeToken.address,
-                partners,
-                remainderDestination.address
-            );
+    it('Should not let deploy with invalid shares', async function () {
+      const partners = await buildPartners(
+        [partner1, partner2, partner3, partner4],
+        [25, 25, 25, 26]
+      );
 
-            expect(await collector.owner(), 'Failed to set the owner').to.be.a.properAddress;
-            expect(await collector.token(), 'Failed to set the token').not.to.be.null;
-        });
-
-        it('Should not let deploy with invalid shares', async function()  {
-            const partners = await buildPartners(
-                [partner1, partner2, partner3, partner4],
-                [25, 25, 25, 26]
-            );
-
-            await expect(
-                collectorFactory.deploy(
-                    owner.address,
-                    fakeToken.address,
-                    partners,
-                    remainderDestination.address
-                )
-            ).to.be.revertedWith('Shares must add up to 100%');
-        });
-
-        it('Should not let deploy if the array of partners is empty', async function()  {
-            const partners: Partner[] = [];
-
-            await expect(
-                collectorFactory.deploy(
-                    owner.address,
-                    fakeToken.address,
-                    partners,
-                    remainderDestination.address
-                )
-            ).to.be.revertedWith('Shares must add up to 100%');
-        });
-        
-        it('Should not let deploy if a share is 0', async function () {
-            const partners = await buildPartners(
-                [partner1, partner2, partner3, partner4],
-                [30, 30, 0, 40]
-            );
-
-            await expect(
-                collectorFactory.deploy(
-                    owner.address,
-                    fakeToken.address,
-                    partners,
-                    remainderDestination.address
-                )
-            ).to.be.revertedWith('0 is not a valid share');
-        });
+      await expect(
+        collectorFactory.deploy(
+          owner.address,
+          fakeToken.address,
+          partners,
+          remainderDestination.address
+        )
+      ).to.be.revertedWith('Shares must add up to 100%');
     });
 
-    describe('updateShares', function (){
-        beforeEach(async function(){
-            await deployCollector();
-        });
+    it('Should not let deploy if the array of partners is empty', async function () {
+      const partners: Partner[] = [];
 
-        it('Should update shares and partners when token balance is zero', async function() {
-            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
-
-            const newPartners = await buildPartners(
-                [newPartner1, newPartner2, newPartner3, newPartner4],
-                PARTNER_SHARES
-            );
-
-            await collector.updateShares(newPartners);
-
-            expect(collector.updateShares).to.have.been.called;
-        });
-
-        it('Should update shares and partners when token balance is a remainder amount', async function() {
-            fakeToken.balanceOf.returns(3);
-
-            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
-
-            const newPartners = await buildPartners(
-                [newPartner1, newPartner2, newPartner3, newPartner4],
-                PARTNER_SHARES
-            );
-
-            await collector.updateShares(newPartners);            
-
-            expect(collector.updateShares).to.have.been.called;
-        });
-
-        it('Should fail when token balance is grater than a remainder', async function() {
-            fakeToken.balanceOf.returns(5);
-
-            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
-
-            const newPartners = await buildPartners(
-                [newPartner1, newPartner2, newPartner3, newPartner4],
-                PARTNER_SHARES
-            );          
-
-            await expect(
-                collector.updateShares(newPartners)
-            ).to.be.revertedWith('There is balance to share');
-        });
-
-        it('Should fail when is called by an account different than the owner', async function() {
-            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4, notTheOwner ] = await hardhat.getSigners();
-
-            const newPartners = await buildPartners(
-                [newPartner1, newPartner2, newPartner3, newPartner4],
-                PARTNER_SHARES
-            );
-
-            await expect(
-                collector.connect(notTheOwner).updateShares(newPartners)
-            ).to.be.revertedWith('Only owner can call this');
-        });
-
-        it('Should fail if the shares does not sum up to 100', async function() {
-            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
-
-            const newPartners = await buildPartners(
-                [newPartner1, newPartner2, newPartner3, newPartner4],
-                [25, 25, 25, 26]
-            );         
-
-            await expect(
-                collector.updateShares(newPartners)
-            ).to.be.revertedWith('Shares must add up to 100%');
-        });
-
-        it('Should fail if a share is 0', async function() {
-            const[,,,,,, newPartner1, newPartner2, newPartner3, newPartner4 ] = await hardhat.getSigners();
-
-            const newPartners = await buildPartners(
-                [newPartner1, newPartner2, newPartner3, newPartner4],
-                [30, 30, 40, 0]
-            );         
-
-            await expect(
-                collector.updateShares(newPartners)
-            ).to.be.revertedWith('0 is not a valid share');
-        });
-    }); 
-
-    describe('updateRemainderAddress', function() {
-        beforeEach(async function(){
-            await deployCollector();
-        });
-
-        it('Should update remainder address when token balance is zero', async function() {
-            const[,,,,,, newReminderDestination] = await hardhat.getSigners();
-
-            await collector.updateRemainderAddress(newReminderDestination.address);
-
-            expect(collector.updateRemainderAddress).to.have.been.called;
-        });
-
-        it('Should update remainder when token balance is a remainder and should withdraw remainder', async function() {
-            fakeToken.balanceOf.returns(3);
-
-            const[,,,,,, newRemainderDestination] = await hardhat.getSigners();
-
-            await collector.updateRemainderAddress(newRemainderDestination.address);
-
-            expect(
-                fakeToken.transfer
-            ).to.have.been.calledWith(remainderDestination.address, 3);
-        });
-
-        it('Should withdraw when the remainders address sent is the same as the current one', async function() {
-            fakeToken.balanceOf.returns(3);
-
-            await collector.updateRemainderAddress(remainderDestination.address);
-
-            expect(
-                fakeToken.transfer
-            ).to.have.been.calledWith(remainderDestination.address, 3);
-        });
-
-        it('Should fail when token balance > = remainder', async function() {
-            fakeToken.balanceOf.returns(5);
-
-            const[,,,,,, newRemainderDestination] = await hardhat.getSigners();
-
-            await expect(
-                collector.updateRemainderAddress(newRemainderDestination.address)
-            ).to.be.revertedWith('There is balance to share');
-        });
-
-        it('Should fail when is called by an address that is not the owner', async function() {
-            fakeToken.balanceOf.returns(5);
-
-            const[,,,,,, newRemainderDestination, notTheOwner] = await hardhat.getSigners();
-
-            await expect(
-                collector.connect(notTheOwner).updateRemainderAddress(newRemainderDestination.address)
-            ).to.be.revertedWith('Only owner can call this');
-        });
+      await expect(
+        collectorFactory.deploy(
+          owner.address,
+          fakeToken.address,
+          partners,
+          remainderDestination.address
+        )
+      ).to.be.revertedWith('Shares must add up to 100%');
     });
 
-    describe('getBalance()', function() {
-        beforeEach(async function(){
-            await deployCollector();
-        });
+    it('Should not let deploy if a share is 0', async function () {
+      const partners = await buildPartners(
+        [partner1, partner2, partner3, partner4],
+        [30, 30, 0, 40]
+      );
 
-        it('Should return 0 if the contract has been just deployed', async function() {
-            fakeToken.balanceOf.returns(0);
+      await expect(
+        collectorFactory.deploy(
+          owner.address,
+          fakeToken.address,
+          partners,
+          remainderDestination.address
+        )
+      ).to.be.revertedWith('0 is not a valid share');
+    });
+  });
 
-            expect(await collector.getBalance()).to.equal(0);
-        });
-
-        it('Should return 100 after that value has been minted', async function() {
-            fakeToken.balanceOf.returns(100);
-
-            expect(await collector.getBalance()).to.equal(100);
-        });
+  describe('updateShares', function () {
+    beforeEach(async function () {
+      await deployCollector();
     });
 
-    describe('withdraw', function() {
-        beforeEach(async function(){
-            await deployCollector();
-        });
+    it('Should update shares and partners when token balance is zero', async function () {
+      const [, , , , , , newPartner1, newPartner2, newPartner3, newPartner4] =
+        await hardhat.getSigners();
 
-        it('Should withdraw', async function() {
-            fakeToken.balanceOf.returns(100);
-            await collector.withdraw();
+      const newPartners = await buildPartners(
+        [newPartner1, newPartner2, newPartner3, newPartner4],
+        PARTNER_SHARES
+      );
 
-            expect(
-                fakeToken.transfer,
-                'Partner[0] balance'
-            ).to.have.been.calledWith(partners[0].beneficiary, PARTNER_SHARES[0]);
+      await collector.updateShares(newPartners);
 
-            expect(
-                fakeToken.transfer,
-                'Partner[1] balance'
-            ).to.have.been.calledWith(partners[1].beneficiary, PARTNER_SHARES[1]);
-
-            expect(
-                fakeToken.transfer,
-                'Partner[2] balance'
-            ).to.have.been.calledWith(partners[2].beneficiary, PARTNER_SHARES[2]);
-
-            expect(
-                fakeToken.transfer,
-                'Partner[3] balance'
-            ).to.have.been.calledWith(partners[3].beneficiary, PARTNER_SHARES[3]);
-        });
-
-        it('Should not fail if the revenue to share is equal to the number of partners', async function() {
-            // We assume the current balance of the collector to be
-            // equal to the number of partners
-            fakeToken.balanceOf.returns(NUMBER_OF_PARTNERS);
-
-            await collector.withdraw();
-
-            expect(
-                fakeToken.transfer
-            ).to.have.callCount(4);
-        });
-
-        it('Should fail when no revenue to share', async function() {
-            fakeToken.balanceOf.returns(NUMBER_OF_PARTNERS - 1);
-
-            await expect(
-                collector.withdraw()
-            ).to.be.revertedWith('Not enough balance to split');
-        });
-
-        it('Should fail when is called by an address that is not the owner', async function() {
-            fakeToken.balanceOf.returns(100);
-
-            const[,,,,,, notTheOwner] = await hardhat.getSigners();
-
-            await expect(
-                collector.connect(notTheOwner).withdraw()
-            ).to.be.revertedWith('Only owner can call this');
-        });
+      expect(collector.updateShares).to.have.been.called;
     });
 
-    describe('transferOwnership', function() {
-        beforeEach(async function(){
-            await deployCollector();
-        });
+    it('Should update shares and partners when token balance is a remainder amount', async function () {
+      fakeToken.balanceOf.returns(3);
 
-        it('Should transfer ownership', async function() {
-            const[,,,,,, newOwner] = await hardhat.getSigners();
+      const [, , , , , , newPartner1, newPartner2, newPartner3, newPartner4] =
+        await hardhat.getSigners();
 
-            await collector.transferOwnership(newOwner.address);
+      const newPartners = await buildPartners(
+        [newPartner1, newPartner2, newPartner3, newPartner4],
+        PARTNER_SHARES
+      );
 
-            expect(await collector.owner()).to.be.equal(newOwner.address);
-        });
+      await collector.updateShares(newPartners);
 
-        it('Should fail when is called by an address that is not the owner', async function() {
-            const[,,,,,, newOwner, notTheOwner] = await hardhat.getSigners();
-
-            await expect(
-                collector.connect(notTheOwner).transferOwnership(newOwner.address)
-            ).to.be.revertedWith('Only owner can call this');
-        });
+      expect(collector.updateShares).to.have.been.called;
     });
+
+    it('Should fail when token balance is grater than a remainder', async function () {
+      fakeToken.balanceOf.returns(5);
+
+      const [, , , , , , newPartner1, newPartner2, newPartner3, newPartner4] =
+        await hardhat.getSigners();
+
+      const newPartners = await buildPartners(
+        [newPartner1, newPartner2, newPartner3, newPartner4],
+        PARTNER_SHARES
+      );
+
+      await expect(collector.updateShares(newPartners)).to.be.revertedWith(
+        'There is balance to share'
+      );
+    });
+
+    it('Should fail when is called by an account different than the owner', async function () {
+      const [
+        ,
+        ,
+        ,
+        ,
+        ,
+        ,
+        newPartner1,
+        newPartner2,
+        newPartner3,
+        newPartner4,
+        notTheOwner,
+      ] = await hardhat.getSigners();
+
+      const newPartners = await buildPartners(
+        [newPartner1, newPartner2, newPartner3, newPartner4],
+        PARTNER_SHARES
+      );
+
+      await expect(
+        collector.connect(notTheOwner).updateShares(newPartners)
+      ).to.be.revertedWith('Only owner can call this');
+    });
+
+    it('Should fail if the shares does not sum up to 100', async function () {
+      const [, , , , , , newPartner1, newPartner2, newPartner3, newPartner4] =
+        await hardhat.getSigners();
+
+      const newPartners = await buildPartners(
+        [newPartner1, newPartner2, newPartner3, newPartner4],
+        [25, 25, 25, 26]
+      );
+
+      await expect(collector.updateShares(newPartners)).to.be.revertedWith(
+        'Shares must add up to 100%'
+      );
+    });
+
+    it('Should fail if a share is 0', async function () {
+      const [, , , , , , newPartner1, newPartner2, newPartner3, newPartner4] =
+        await hardhat.getSigners();
+
+      const newPartners = await buildPartners(
+        [newPartner1, newPartner2, newPartner3, newPartner4],
+        [30, 30, 40, 0]
+      );
+
+      await expect(collector.updateShares(newPartners)).to.be.revertedWith(
+        '0 is not a valid share'
+      );
+    });
+  });
+
+  describe('updateRemainderAddress', function () {
+    beforeEach(async function () {
+      await deployCollector();
+    });
+
+    it('Should update remainder address when token balance is zero', async function () {
+      const [, , , , , , newReminderDestination] = await hardhat.getSigners();
+
+      await collector.updateRemainderAddress(newReminderDestination.address);
+
+      expect(collector.updateRemainderAddress).to.have.been.called;
+    });
+
+    it('Should update remainder when token balance is a remainder and should withdraw remainder', async function () {
+      fakeToken.balanceOf.returns(3);
+
+      const [, , , , , , newRemainderDestination] = await hardhat.getSigners();
+
+      await collector.updateRemainderAddress(newRemainderDestination.address);
+
+      expect(fakeToken.transfer).to.have.been.calledWith(
+        remainderDestination.address,
+        3
+      );
+    });
+
+    it('Should withdraw when the remainders address sent is the same as the current one', async function () {
+      fakeToken.balanceOf.returns(3);
+
+      await collector.updateRemainderAddress(remainderDestination.address);
+
+      expect(fakeToken.transfer).to.have.been.calledWith(
+        remainderDestination.address,
+        3
+      );
+    });
+
+    it('Should fail when token balance > = remainder', async function () {
+      fakeToken.balanceOf.returns(5);
+
+      const [, , , , , , newRemainderDestination] = await hardhat.getSigners();
+
+      await expect(
+        collector.updateRemainderAddress(newRemainderDestination.address)
+      ).to.be.revertedWith('There is balance to share');
+    });
+
+    it('Should fail when is called by an address that is not the owner', async function () {
+      fakeToken.balanceOf.returns(5);
+
+      const [, , , , , , newRemainderDestination, notTheOwner] =
+        await hardhat.getSigners();
+
+      await expect(
+        collector
+          .connect(notTheOwner)
+          .updateRemainderAddress(newRemainderDestination.address)
+      ).to.be.revertedWith('Only owner can call this');
+    });
+  });
+
+  describe('getBalance()', function () {
+    beforeEach(async function () {
+      await deployCollector();
+    });
+
+    it('Should return 0 if the contract has been just deployed', async function () {
+      fakeToken.balanceOf.returns(0);
+
+      expect(await collector.getBalance()).to.equal(0);
+    });
+
+    it('Should return 100 after that value has been minted', async function () {
+      fakeToken.balanceOf.returns(100);
+
+      expect(await collector.getBalance()).to.equal(100);
+    });
+  });
+
+  describe('withdraw', function () {
+    beforeEach(async function () {
+      await deployCollector();
+    });
+
+    it('Should withdraw', async function () {
+      fakeToken.balanceOf.returns(100);
+      await collector.withdraw();
+
+      expect(fakeToken.transfer, 'Partner[0] balance').to.have.been.calledWith(
+        partners[0].beneficiary,
+        PARTNER_SHARES[0]
+      );
+
+      expect(fakeToken.transfer, 'Partner[1] balance').to.have.been.calledWith(
+        partners[1].beneficiary,
+        PARTNER_SHARES[1]
+      );
+
+      expect(fakeToken.transfer, 'Partner[2] balance').to.have.been.calledWith(
+        partners[2].beneficiary,
+        PARTNER_SHARES[2]
+      );
+
+      expect(fakeToken.transfer, 'Partner[3] balance').to.have.been.calledWith(
+        partners[3].beneficiary,
+        PARTNER_SHARES[3]
+      );
+    });
+
+    it('Should not fail if the revenue to share is equal to the number of partners', async function () {
+      // We assume the current balance of the collector to be
+      // equal to the number of partners
+      fakeToken.balanceOf.returns(NUMBER_OF_PARTNERS);
+
+      await collector.withdraw();
+
+      expect(fakeToken.transfer).to.have.callCount(4);
+    });
+
+    it('Should fail when no revenue to share', async function () {
+      fakeToken.balanceOf.returns(NUMBER_OF_PARTNERS - 1);
+
+      await expect(collector.withdraw()).to.be.revertedWith(
+        'Not enough balance to split'
+      );
+    });
+
+    it('Should fail when is called by an address that is not the owner', async function () {
+      fakeToken.balanceOf.returns(100);
+
+      const [, , , , , , notTheOwner] = await hardhat.getSigners();
+
+      await expect(
+        collector.connect(notTheOwner).withdraw()
+      ).to.be.revertedWith('Only owner can call this');
+    });
+  });
+
+  describe('transferOwnership', function () {
+    beforeEach(async function () {
+      await deployCollector();
+    });
+
+    it('Should transfer ownership', async function () {
+      const [, , , , , , newOwner] = await hardhat.getSigners();
+
+      await collector.transferOwnership(newOwner.address);
+
+      expect(await collector.owner()).to.be.equal(newOwner.address);
+    });
+
+    it('Should fail when is called by an address that is not the owner', async function () {
+      const [, , , , , , newOwner, notTheOwner] = await hardhat.getSigners();
+
+      await expect(
+        collector.connect(notTheOwner).transferOwnership(newOwner.address)
+      ).to.be.revertedWith('Only owner can call this');
+    });
+  });
 });


### PR DESCRIPTION
## What

- Rewrite the unit tests for the Collector contract using Hardhat and Ethers.js

## Why

- Modernization of the project and quality improvements.

## Refs

- [PP-478](https://rsklabs.atlassian.net/browse/PP-478)