### PR TITLE
PP-513: fix IWalletCustomLogic interface to reflect IForwarder changes

### DIFF
--- a/contracts/interfaces/IWalletCustomLogic.sol
+++ b/contracts/interfaces/IWalletCustomLogic.sol
@@ -22,6 +22,7 @@ interface IWalletCustomLogic {
     function execute(
         bytes32 suffixData,
         IForwarder.ForwardRequest calldata forwardRequest,
+        address feesReceiver,
         bytes calldata signature
     )
     external payable

--- a/contracts/test/FailureCustomLogic.sol
+++ b/contracts/test/FailureCustomLogic.sol
@@ -25,6 +25,7 @@ contract FailureCustomLogic is IWalletCustomLogic {
     function execute(
         bytes32 suffixData,
         IForwarder.ForwardRequest memory req,
+        address feesReceiver,
         bytes calldata sig
     ) override external payable returns (bytes memory ret) {
         revert("always fail");

--- a/contracts/test/ProxyCustomLogic.sol
+++ b/contracts/test/ProxyCustomLogic.sol
@@ -25,6 +25,7 @@ contract ProxyCustomLogic is IWalletCustomLogic {
     function execute(
         bytes32 suffixData,
         IForwarder.ForwardRequest memory req,
+        address feesReceiver,
         bytes calldata sig
     ) override external payable returns (bytes memory ret) {
         emit LogicCalled();  

--- a/contracts/test/SuccessCustomLogic.sol
+++ b/contracts/test/SuccessCustomLogic.sol
@@ -26,9 +26,10 @@ contract SuccessCustomLogic is IWalletCustomLogic {
     function execute(
         bytes32 suffixData,
         IForwarder.ForwardRequest memory req,
+        address feesReceiver,
         bytes calldata sig
     ) override external payable returns (bytes memory ret) {
-        emit LogicCalled();     
+        emit LogicCalled();
         ret = "success";
     }
 


### PR DESCRIPTION
## What

- Update the interface of `IWalletCustomLogic` to reflect `IForwarder` changes

## Why

- The contracts `FailureCustomLogic.sol`,  `ProxyCustomLogic.sol`, `SuccessCustomLogic.sol`) are used in the integration tests and extends `IWalletCustomLogic`, so we need to update them in order to successfully call those contracts.
