### PR TITLE
PP-532: fix SmartWallet unit tests broken by REL-002

### DIFF
--- a/test/smartwallet/CustomSmartWallet.template.test.ts
+++ b/test/smartwallet/CustomSmartWallet.template.test.ts
@@ -9,7 +9,7 @@ chai.use(chaiAsPromised);
 
 const ZERO_ADDRESS = hardhat.constants.AddressZero;
 
-describe('CustomSmartWalletTemplate', function(){
+describe('CustomSmartWallet template', function(){
     describe('Function initialize()', function() {
         let customSmartWalletMock: MockContract<CustomSmartWallet>;
 

--- a/test/smartwallet/customSmartWallet.test.ts
+++ b/test/smartwallet/customSmartWallet.test.ts
@@ -133,7 +133,7 @@ function buildDomainSeparator(address: string ){
     return hardhat.utils._TypedDataEncoder.hashDomain(domainSeparator);
 }
 
-describe('CustomSmartWallet', function(){
+describe('CustomSmartWallet contract', function(){
     //This function is being tested as an integration test due to the lack
     //of tools for properly creating unit testing in these specific scenarios
     describe('Function initialize()', function(){

--- a/test/smartwallet/smartWallet.template.test.ts
+++ b/test/smartwallet/smartWallet.template.test.ts
@@ -1,38 +1,40 @@
-// import { use, expect } from 'chai';
-// import chaiAsPromised from 'chai-as-promised';
+import { MockContract, smock } from '@defi-wonderland/smock';
+import { SmartWallet, SmartWallet__factory } from 'typechain-types';
+import chai, { expect} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {ethers as hardhat} from 'hardhat';
 
-// import { SmartWalletInstance } from '../../types/truffle-contracts';
-// import { constants } from '../constants';
+chai.use(smock.matchers);
+chai.use(chaiAsPromised);
 
-// use(chaiAsPromised);
+const ZERO_ADDRESS = hardhat.constants.AddressZero;
 
-// const SmartWallet = artifacts.require('SmartWallet');
+describe('SmartWallet template', function(){
+    describe('Function initialize()', function() {
+        let smartWalletMock: MockContract<SmartWallet>;
 
-// contract('SmartWallet - template', ([owner]) => {
-//     describe('initialize', () => {
-//         let smartWallet: SmartWalletInstance;
+        beforeEach(async function(){
+            const smartWalletFactoryMock = 
+                await smock.mock<SmartWallet__factory>('CustomSmartWallet');
+        
+            smartWalletMock = await smartWalletFactoryMock.deploy();
+        });
 
-//         beforeEach(async () => {
-//             smartWallet = await SmartWallet.new();
-//         });
+        it('Should be initialized during the deployment', async function(){
+            expect(await smartWalletMock.isInitialized()).to.be.true;
+        });
 
-//         it('Should be initialized during the deployment', async () => {
-//             await expect(smartWallet.isInitialized()).to.eventually.be.true;
-//         });
-
-//         it('Should verify method initialize fails when contract has already deployed', async () => {
-//             const tokenAddress = constants.ZERO_ADDRESS;
-//             const recipient = constants.ZERO_ADDRESS;
-
-//             await expect(
-//                 smartWallet.initialize(
-//                     owner,
-//                     tokenAddress,
-//                     recipient,
-//                     '0',
-//                     '5000'
-//                 )
-//             ).to.be.rejectedWith('already initialized');
-//         });
-//     });
-// });
+        it('Should fail to initialize if alredy initialized', async function(){
+            const[owner] = await hardhat.getSigners();
+            await expect(smartWalletMock.initialize(
+                owner.address,
+                ZERO_ADDRESS,
+                ZERO_ADDRESS,
+                ZERO_ADDRESS,
+                '0',
+                '50000',
+                '0x'
+            )).to.be.rejectedWith('already initialized');
+        });
+    });
+});

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -191,23 +191,41 @@ describe('SmartWallet contract', function(){
             fakeToken = await smock.fake('ERC20');
         });
 
-        it('Should initialize a SmartWallet', async function(){
-            const dataTypesToSign = ['bytes2', 'address', 'address', 'uint256'];
-            const valuesToSign = ['0x1910', owner.address, ZERO_ADDRESS, 0 ];
+        describe('', function() {
+            let smartWallet: SmartWallet;
 
-            const signature = signData(dataTypesToSign, valuesToSign);
+            beforeEach(async function() {
+                const dataTypesToSign = ['bytes2', 'address', 'address', 'uint256'];
+                const valuesToSign = ['0x1910', owner.address, ZERO_ADDRESS, 0 ];
 
-            await smartWalletFactory.createUserSmartWallet(
-                owner.address,
-                ZERO_ADDRESS,
-                '0',
-                signature
-            );
+                const signature = signData(dataTypesToSign, valuesToSign);
 
-            const smartWallet = await getAlreadyDeployedSmartWallet();
+                await smartWalletFactory.createUserSmartWallet(
+                    owner.address,
+                    ZERO_ADDRESS,
+                    '0',
+                    signature
+                );
 
-            expect(await smartWallet.isInitialized()).to.be.true;
-        });
+                smartWallet = await getAlreadyDeployedSmartWallet();
+            })
+
+            it('Should initialize a SmartWallet', async function(){
+                expect(await smartWallet.isInitialized()).to.be.true;
+            });
+
+            it('Should fail to initialize a SmartWallet twice', async function(){
+                await expect(
+                    smartWallet.initialize(owner.address, fakeToken.address, ZERO_ADDRESS, 10, 400000),
+                    'Second initialization not rejected'
+                ).to.be.revertedWith('already initialized');
+            });
+    
+            it('Should create the domainSeparator', async function () {
+    
+                expect(await smartWallet.domainSeparator()).to.be.properHex(64);
+            });
+        })
 
         it('Should call transfer on not sponsored deployment', async function(){
             const deployRequest = createDeployRequest({
@@ -266,45 +284,6 @@ describe('SmartWallet contract', function(){
 
             expect(fakeToken.transfer).not.to.be.called;
         })
-
-        it('Should fail to initialize a SmartWallet twice', async function(){
-            const dataTypesToSign = ['bytes2', 'address', 'address', 'uint256'];
-            const valuesToSign = ['0x1910', owner.address, ZERO_ADDRESS, 0 ];
-
-            const signature = signData(dataTypesToSign, valuesToSign);
-
-            await smartWalletFactory.createUserSmartWallet(
-                owner.address,
-                ZERO_ADDRESS,
-                '0',
-                signature
-            );
-
-            const smartWallet = await getAlreadyDeployedSmartWallet();
-
-            await expect(
-                smartWallet.initialize(owner.address, fakeToken.address, ZERO_ADDRESS, 10, 400000),
-                'Second initialization not rejected'
-            ).to.be.revertedWith('already initialized');
-        });
-
-        it('Should create the domainSeparator', async function () {
-            const dataTypesToSign = ['bytes2', 'address', 'address', 'uint256'];
-            const valuesToSign = ['0x1910', owner.address, ZERO_ADDRESS, 0 ];
-            
-            const signature = signData(dataTypesToSign, valuesToSign);
-
-            await smartWalletFactory.createUserSmartWallet(
-                owner.address,
-                ZERO_ADDRESS,
-                '0',
-                signature
-            );
-
-            const smartWallet = await getAlreadyDeployedSmartWallet();
-
-            expect(await smartWallet.domainSeparator()).to.be.properHex(64);
-        });
 
         it('Should fail when the token transfer method fails', async function () {
             const deployRequest = createDeployRequest({
@@ -612,7 +591,7 @@ describe('SmartWallet contract', function(){
         });
     });
 
-    describe('Function directKExecute()', function(){
+    describe('Function directExecute()', function(){
         let mockSmartWallet: MockContract<SmartWallet>;
         let provider: BaseProvider;
         let owner: Wallet;
@@ -680,13 +659,6 @@ describe('SmartWallet contract', function(){
             const amountToTransferAsNumber = Number(hardhat.utils.formatEther(amountToTransfer));
 
             expect(difference).approximately(amountToTransferAsNumber, 2);
-        });
-    });
-
-    describe.skip('Function recover()', function(){
-        //TODO: This function is not implemented. Create test cases when it is.
-        it('Should recover founds....', function () {
-            console.log('Not implemented yet')
         });
     });
 });


### PR DESCRIPTION
## What

- Rewrite unit test for SmartWallet contract in order to fix them.

## Why

-  The test were broken after the implementation of REL-002

## Refs

- [PP-532](https://rsklabs.atlassian.net/browse/PP-532)
