### PR TITLE
PP-584 (REL-005): Add secure transfer in the Collector

### DIFF
--- a/contracts/Collector.sol
+++ b/contracts/Collector.sol
@@ -77,6 +77,7 @@ contract Collector is ICollector{
         address tokenAddr = address(token);
 
         if(balance != 0) {
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, bytes memory ret ) = tokenAddr.call{gas: 200000}(abi.encodeWithSelector(
                 hex"a9059cbb",
                 remainderAddress,
@@ -110,6 +111,7 @@ contract Collector is ICollector{
         address tokenAddr = address(token);
 
         for(uint256 i = 0; i < partners.length; i++){
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, bytes memory ret ) = tokenAddr.call(abi.encodeWithSelector(
                 hex"a9059cbb",
                 partners[i].beneficiary,

--- a/contracts/Collector.sol
+++ b/contracts/Collector.sol
@@ -5,8 +5,11 @@ pragma experimental ABIEncoderV2;
 import "./interfaces/ICollector.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
 contract Collector is ICollector{
+    using SafeERC20 for IERC20;
+
     address private remainderAddress;
     RevenuePartner[] private partners;
     IERC20 public token;
@@ -76,7 +79,7 @@ contract Collector is ICollector{
         uint256 balance = token.balanceOf(address(this));
 
         if(balance != 0) {
-            token.transfer(remainderAddress, balance);
+            token.safeTransfer(remainderAddress, balance);
         }
 
         // solhint-disable-next-line
@@ -99,7 +102,7 @@ contract Collector is ICollector{
         require(balance >= partners.length, "Not enough balance to split");
 
         for(uint256 i = 0; i < partners.length; i++)
-            token.transfer(partners[i].beneficiary, SafeMath.div(SafeMath.mul(balance, partners[i].share), 100));
+            token.safeTransfer(partners[i].beneficiary, SafeMath.div(SafeMath.mul(balance, partners[i].share), 100));
     }
 
     function transferOwnership(address _owner)

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -320,7 +320,7 @@ describe('Collector', () => {
                     from: owner.address,
                     gasLimit: 100000
                 })
-            ).to.be.reverted;
+            ).to.be.revertedWith('Unable to transfer remainder');
         });
     });
 
@@ -415,7 +415,7 @@ describe('Collector', () => {
             ).to.be.revertedWith('Only owner can call this');
         });
 
-        it('Should fail when the transfer fails', async () => {
+        it('Should fail if the transfer returns false', async () => {
             const [owner, remainder, partner1, partner2, partner3, partner4] =
                 new MockProvider().getWallets();
 
@@ -436,8 +436,8 @@ describe('Collector', () => {
             ]);
 
             await expect(
-                collector.withdraw({ from: owner.address, gasLimit: 100000 })
-            ).to.be.reverted;
+                collector.withdraw({ from: owner.address, gasLimit: 1000000 })
+            ).to.be.revertedWith('Unable to withdraw');
         });
     });
 


### PR DESCRIPTION
## What

- Change the use of transfer from ERC20 to .call.

## Why

- Security bug found in REL-005.

## Refs

- [PP-584](https://rsklabs.atlassian.net/browse/PP-584)
