### PR TITLE
PP-597: Change the configuration to use custom signers to run the script

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,19 +1,34 @@
 import '@nomicfoundation/hardhat-toolbox';
+import '@nomiclabs/hardhat-ethers';
+import dotenv from 'dotenv';
 import 'hardhat-contract-sizer';
 import 'hardhat-docgen';
 import 'hardhat-watcher';
-import '@nomiclabs/hardhat-ethers';
-import { allowTokens } from './tasks/allowTokens';
-import { removeTokens } from './tasks/removeTokens';
-import { deploy } from './tasks/deploy';
-import { withdraw, WithdrawSharesArg } from './tasks/withdraw';
 import { HardhatUserConfig, task } from 'hardhat/config';
-import { getAllowedTokens } from './tasks/getAllowedTokens';
-import { deployCollector, DeployCollectorArg } from './tasks/deployCollector';
+import { HttpNetworkUserConfig } from 'hardhat/types';
+import { allowTokens } from './tasks/allowTokens';
 import {
   changePartnerShares,
   ChangePartnerSharesArg,
 } from './tasks/changePartnerShares';
+import { deploy } from './tasks/deploy';
+import { deployCollector, DeployCollectorArg } from './tasks/deployCollector';
+import { getAllowedTokens } from './tasks/getAllowedTokens';
+import { removeTokens } from './tasks/removeTokens';
+import { withdraw, WithdrawSharesArg } from './tasks/withdraw';
+dotenv.config();
+
+const DEFAULT_MNEMONIC =
+  'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+const { PK, MNEMONIC } = process.env;
+const sharedNetworkConfig: HttpNetworkUserConfig = {};
+if (PK) {
+  sharedNetworkConfig.accounts = [PK];
+} else {
+  sharedNetworkConfig.accounts = {
+    mnemonic: MNEMONIC || DEFAULT_MNEMONIC,
+  };
+}
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -38,6 +53,11 @@ const config: HardhatUserConfig = {
     regtest: {
       url: 'http://localhost:4444',
       chainId: 33,
+    },
+    testnet: {
+      ...sharedNetworkConfig,
+      url: 'https://public-node.testnet.rsk.co',
+      chainId: 31,
     },
   },
   typechain: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@rsksmart/rif-relay-contracts",
-  "version": "1.0.2-alpha.1",
+  "version": "1.0.2-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rif-relay-contracts",
-      "version": "1.0.2-alpha.1",
+      "version": "1.0.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@metamask/eth-sig-util": "^4.0.1",
         "@nomicfoundation/hardhat-toolbox": "^2.0.0",
         "@nomiclabs/hardhat-ethers": "^2.1.1",
         "@openzeppelin/contracts": "^3.4.0",
+        "dotenv": "^16.0.3",
         "hardhat": "^2.10.2",
         "hardhat-contract-sizer": "^2.6.1",
         "hardhat-docgen": "^1.3.0",
@@ -314,9 +315,9 @@
       }
     },
     "node_modules/@commitlint/load/node_modules/@types/node": {
-      "version": "14.18.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
       "dev": true
     },
     "node_modules/@commitlint/message": {
@@ -1529,9 +1530,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.4.tgz",
-      "integrity": "sha512-n/5UMwGaUK2zM8ALuMChVwB1lEPeDTb5oBjQ1g7hVsUdS8x+XG9JIEp4Ze6Bwy98tghA7Y1+PCH4SNE2P3UQ2g==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.5.tgz",
+      "integrity": "sha512-+W5C/+5FHI2xBajUN9THSNc1UP6FUsA7LeLmfnaC9VMi/50/DEjjxd8OmizEXgV1Bjck7my4NVQLL1Ti39FkpA==",
       "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
@@ -1620,9 +1621,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.6.tgz",
-      "integrity": "sha512-a35iVD4ycF6AoTfllAnKm96IPIzzHpgKX/ep4oKc2bsUKFfMlacWdyntgC/7d5blyCTXfFssgNAvXDZfzNWVGQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.7.tgz",
+      "integrity": "sha512-X+3mNvn8B7BY5hpIaLO+TrfzWq12bpux+ajGGdmdcfC78NXmYmOZkAtiz1QZx1YIZGMS1LaXzPXyBExxKFpCaw==",
       "peer": true,
       "dependencies": {
         "ethereumjs-util": "^7.1.4"
@@ -1862,14 +1863,14 @@
       }
     },
     "node_modules/@nomiclabs/hardhat-etherscan": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.2.tgz",
-      "integrity": "sha512-IEikeOVq0C/7CY6aD74d8L4BpGoc/FNiN6ldiPVg0QIFIUSu4FSGA1dmtJZJKk1tjpwgrfTLQNWnigtEaN9REg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.3.tgz",
+      "integrity": "sha512-UeNO97j0lwOHqX7mrH6SfQQBdXq1Ng6eFr7uJKuQOrq2UVTWGD70lE5QO4fAFVPz9ao+xlNpMyIqSR7+OaDR+Q==",
       "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
-        "cbor": "^5.0.2",
+        "cbor": "^8.1.0",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "fs-extra": "^7.0.1",
@@ -2373,9 +2374,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
+      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3289,15 +3290,6 @@
         "node": ">=10.4.0"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3571,9 +3563,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001434",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+      "version": "1.0.30001435",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3600,16 +3592,15 @@
       }
     },
     "node_modules/cbor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
       "peer": true,
       "dependencies": {
-        "bignumber.js": "^9.0.1",
-        "nofilter": "^1.0.4"
+        "nofilter": "^3.1.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=12.19"
       }
     },
     "node_modules/chai": {
@@ -4659,6 +4650,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6894,9 +6893,9 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.2.tgz",
-      "integrity": "sha512-f3ZhzXy1uyQv0UXnAQ8GCBOWjzv++WJNb7bnm10SsyC3dB7vlPpsMWBNhq7aoRxKrNhX9tCev81KFV3i5BTeMQ==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.3.tgz",
+      "integrity": "sha512-qxOvRNgQnLqRFssn5f8VP5KN3caytShU0HNeKxmPVK1Ix/0xDVhIC7JOLxG69DjOihUfmxmjqspsHbZvFj6EhQ==",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
@@ -7075,10 +7074,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/hardhat/node_modules/ethereum-cryptography": {
@@ -9462,12 +9458,12 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
     "node_modules/nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.19"
       }
     },
     "node_modules/nopt": {
@@ -12950,9 +12946,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
-      "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -14211,9 +14207,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-          "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
+          "version": "14.18.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+          "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
           "dev": true
         }
       }
@@ -15014,9 +15010,9 @@
       }
     },
     "@nomicfoundation/hardhat-chai-matchers": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.4.tgz",
-      "integrity": "sha512-n/5UMwGaUK2zM8ALuMChVwB1lEPeDTb5oBjQ1g7hVsUdS8x+XG9JIEp4Ze6Bwy98tghA7Y1+PCH4SNE2P3UQ2g==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.5.tgz",
+      "integrity": "sha512-+W5C/+5FHI2xBajUN9THSNc1UP6FUsA7LeLmfnaC9VMi/50/DEjjxd8OmizEXgV1Bjck7my4NVQLL1Ti39FkpA==",
       "peer": true,
       "requires": {
         "@ethersproject/abi": "^5.1.2",
@@ -15086,9 +15082,9 @@
       }
     },
     "@nomicfoundation/hardhat-network-helpers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.6.tgz",
-      "integrity": "sha512-a35iVD4ycF6AoTfllAnKm96IPIzzHpgKX/ep4oKc2bsUKFfMlacWdyntgC/7d5blyCTXfFssgNAvXDZfzNWVGQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.7.tgz",
+      "integrity": "sha512-X+3mNvn8B7BY5hpIaLO+TrfzWq12bpux+ajGGdmdcfC78NXmYmOZkAtiz1QZx1YIZGMS1LaXzPXyBExxKFpCaw==",
       "peer": true,
       "requires": {
         "ethereumjs-util": "^7.1.4"
@@ -15208,14 +15204,14 @@
       "requires": {}
     },
     "@nomiclabs/hardhat-etherscan": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.2.tgz",
-      "integrity": "sha512-IEikeOVq0C/7CY6aD74d8L4BpGoc/FNiN6ldiPVg0QIFIUSu4FSGA1dmtJZJKk1tjpwgrfTLQNWnigtEaN9REg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.3.tgz",
+      "integrity": "sha512-UeNO97j0lwOHqX7mrH6SfQQBdXq1Ng6eFr7uJKuQOrq2UVTWGD70lE5QO4fAFVPz9ao+xlNpMyIqSR7+OaDR+Q==",
       "peer": true,
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
-        "cbor": "^5.0.2",
+        "cbor": "^8.1.0",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "fs-extra": "^7.0.1",
@@ -15640,9 +15636,9 @@
       "peer": true
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
+      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -16343,12 +16339,6 @@
       "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
       "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ=="
     },
-    "bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-      "peer": true
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -16560,9 +16550,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001434",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
+      "version": "1.0.30001435",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -16576,13 +16566,12 @@
       "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
     },
     "cbor": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
       "peer": true,
       "requires": {
-        "bignumber.js": "^9.0.1",
-        "nofilter": "^1.0.4"
+        "nofilter": "^3.1.0"
       }
     },
     "chai": {
@@ -17368,6 +17357,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "eastasianwidth": {
       "version": "0.2.0",
@@ -18402,15 +18396,6 @@
             "lodash": "^4.17.15",
             "yargs": "^13.3.0"
           }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -19114,9 +19099,9 @@
       "dev": true
     },
     "hardhat": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.2.tgz",
-      "integrity": "sha512-f3ZhzXy1uyQv0UXnAQ8GCBOWjzv++WJNb7bnm10SsyC3dB7vlPpsMWBNhq7aoRxKrNhX9tCev81KFV3i5BTeMQ==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.3.tgz",
+      "integrity": "sha512-qxOvRNgQnLqRFssn5f8VP5KN3caytShU0HNeKxmPVK1Ix/0xDVhIC7JOLxG69DjOihUfmxmjqspsHbZvFj6EhQ==",
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
@@ -21041,9 +21026,9 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
     "nofilter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "peer": true
     },
     "nopt": {
@@ -23681,9 +23666,9 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "terser": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
-      "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-contracts",
-  "version": "1.0.2-alpha.1",
+  "version": "1.0.2-alpha.2",
   "private": false,
   "description": "This project contains all the contracts needed for the rif relay system.",
   "license": "MIT",
@@ -91,6 +91,7 @@
     "@nomicfoundation/hardhat-toolbox": "^2.0.0",
     "@nomiclabs/hardhat-ethers": "^2.1.1",
     "@openzeppelin/contracts": "^3.4.0",
+    "dotenv": "^16.0.3",
     "hardhat": "^2.10.2",
     "hardhat-contract-sizer": "^2.6.1",
     "hardhat-docgen": "^1.3.0",


### PR DESCRIPTION
## What

- Change the configuration to read the custom signers to use from the environment, either by using an env variable or a `.env` file

## Why

- Without it, it's not possible to deploy to Testnet/Mainnet, because there wouldn't be any signer with balance

## How to test

1. Either create a `.env` file or set the following env variables with a private key of an account you've control of ([Here](https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key) a guide on how to export a private key from metamask)
2. Run the command `npx hardhat console --network testnet`
3. Run a simple transaction:
```
account  = (await ethers.getSigners())[0];
tx = await account.sendTransaction({to: 'address_will_receive_trbtc', value: ethers.utils.parseEther('0.01')});
```
4. Get the `tx.hash` value and wait until the transaction is mined.
5. Check the transaction is executed correctly.

