### PR TITLE
PP-653: Fix github action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: "40 22 * * 6"
 


### PR DESCRIPTION
## What

- replace master with main on codeql workflow

## Why

- we don't use master any more.