### PR TITLE
PP-669: Migrate the NativeHolderSmartWallet contract tests to ethers

### DIFF
--- a/contracts/smartwallet/NativeHolderSmartWallet.sol
+++ b/contracts/smartwallet/NativeHolderSmartWallet.sol
@@ -8,7 +8,7 @@ import "./SmartWallet.sol";
 /* solhint-disable avoid-low-level-calls */
 
 contract NativeHolderSmartWallet is SmartWallet {
-    function directExecuteWithValue(
+    function directExecute(
         address to,
         uint256 value,
         bytes calldata data

--- a/tasks/allowTokens.ts
+++ b/tasks/allowTokens.ts
@@ -39,7 +39,12 @@ export const allowTokens = async (
     contractAddressesDeployed.CustomSmartWalletDeployVerifier;
   const customRelayVerifierAddress =
     contractAddressesDeployed.CustomSmartWalletRelayVerifier;
+  const nativeDeployVerifierAddress =
+    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
+  const nativeRelayVerifierAddress =
+    contractAddressesDeployed.NativeHolderSmartWalletRelayVerifier;
 
+  // TODO: This need to be refactored
   if (!deployVerifierAddress) {
     throw new Error('Could not obtain deploy verifier address');
   }
@@ -54,6 +59,18 @@ export const allowTokens = async (
 
   if (!customRelayVerifierAddress) {
     throw new Error('Could not obtain custom deploy verifier address');
+  }
+
+  if (!nativeDeployVerifierAddress) {
+    throw new Error(
+      'Could not obtain deploy verifier address for the NativeHolderSmartWallet'
+    );
+  }
+
+  if (!nativeRelayVerifierAddress) {
+    throw new Error(
+      'Could not obtain relay verifier address for the NativeHolderSmartWallet'
+    );
   }
 
   const deployVerifier = await ethers.getContractAt(
@@ -74,6 +91,15 @@ export const allowTokens = async (
     customRelayVerifierAddress
   );
 
+  const nativeHolderDeployVerifier = await ethers.getContractAt(
+    'DeployVerifier',
+    nativeDeployVerifierAddress
+  );
+  const nativeHolderRelayVerifier = await ethers.getContractAt(
+    'RelayVerifier',
+    nativeRelayVerifierAddress
+  );
+
   const verifierMap: Map<
     string,
     { acceptToken: (tokenAddress: string) => Promise<ContractTransaction> }
@@ -82,6 +108,8 @@ export const allowTokens = async (
   verifierMap.set('relayVerifier', relayVerifier);
   verifierMap.set('customDeployVerifier', customDeployVerifier);
   verifierMap.set('customRelayVerifier', customRelayVerifier);
+  verifierMap.set('nativeHolderDeployVerifier', nativeHolderDeployVerifier);
+  verifierMap.set('nativeHolderRelayVerifier', nativeHolderRelayVerifier);
 
   for (const tokenAddress of tokenAddresses) {
     for (const [key, verifier] of verifierMap) {

--- a/tasks/allowTokens.ts
+++ b/tasks/allowTokens.ts
@@ -1,6 +1,6 @@
 import { ContractTransaction } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { getExistingConfig } from './deploy';
+import { getVerifiers } from './utils';
 
 export const allowTokens = async (
   taskArgs: { tokenlist: string },
@@ -8,97 +8,14 @@ export const allowTokens = async (
 ) => {
   const tokenAddresses = taskArgs.tokenlist.split(',');
 
-  const { ethers, network } = hre;
-
-  if (!network) {
-    throw new Error('Unknown Network');
-  }
-
-  const { chainId } = network.config;
-
-  if (!chainId) {
-    throw new Error('Unknown Chain Id');
-  }
-
-  const contractAddresses = getExistingConfig();
-
-  if (!contractAddresses) {
-    throw new Error('No contracts deployed');
-  }
-
-  const networkChainKey = `${network.name}.${chainId}`;
-  const contractAddressesDeployed = contractAddresses[networkChainKey];
-
-  if (!contractAddressesDeployed) {
-    throw new Error(`Contracts not deployed for chain ID ${chainId}`);
-  }
-
-  const deployVerifierAddress = contractAddressesDeployed.DeployVerifier;
-  const relayVerifierAddress = contractAddressesDeployed.RelayVerifier;
-  const customDeployVerifierAddress =
-    contractAddressesDeployed.CustomSmartWalletDeployVerifier;
-  const customRelayVerifierAddress =
-    contractAddressesDeployed.CustomSmartWalletRelayVerifier;
-  const nativeDeployVerifierAddress =
-    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
-  const nativeRelayVerifierAddress =
-    contractAddressesDeployed.NativeHolderSmartWalletRelayVerifier;
-
-  // TODO: This need to be refactored
-  if (!deployVerifierAddress) {
-    throw new Error('Could not obtain deploy verifier address');
-  }
-
-  if (!relayVerifierAddress) {
-    throw new Error('Could not obtain relay verifier address');
-  }
-
-  if (!customDeployVerifierAddress) {
-    throw new Error('Could not obtain custom deploy verifier address');
-  }
-
-  if (!customRelayVerifierAddress) {
-    throw new Error('Could not obtain custom deploy verifier address');
-  }
-
-  if (!nativeDeployVerifierAddress) {
-    throw new Error(
-      'Could not obtain deploy verifier address for the NativeHolderSmartWallet'
-    );
-  }
-
-  if (!nativeRelayVerifierAddress) {
-    throw new Error(
-      'Could not obtain relay verifier address for the NativeHolderSmartWallet'
-    );
-  }
-
-  const deployVerifier = await ethers.getContractAt(
-    'DeployVerifier',
-    deployVerifierAddress
-  );
-  const relayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    relayVerifierAddress
-  );
-  const customDeployVerifier = await ethers.getContractAt(
-    'CustomSmartWalletDeployVerifier',
-    customDeployVerifierAddress
-  );
-
-  const customRelayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    customRelayVerifierAddress
-  );
-
-  const nativeHolderDeployVerifier = await ethers.getContractAt(
-    'DeployVerifier',
-    nativeDeployVerifierAddress
-  );
-  const nativeHolderRelayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    nativeRelayVerifierAddress
-  );
+  const {
+    deployVerifier,
+    relayVerifier,
+    customDeployVerifier,
+    customRelayVerifier,
+    nativeHolderDeployVerifier,
+    nativeHolderRelayVerifier,
+  } = await getVerifiers(hre);
 
   const verifierMap: Map<
     string,

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -1,21 +1,11 @@
 import { HardhatEthersHelpers, HardhatRuntimeEnvironment } from 'hardhat/types';
 import fs from 'node:fs';
 import { ContractAddresses, NetworkConfig } from '../utils/scripts/types';
-import { parseJsonFile } from './utils';
+import { getExistingConfig } from './utils';
 
 const ADDRESS_FILE = process.env['ADDRESS_FILE'] || 'contract-addresses.json';
 
 export type AddressesConfig = { [key: string]: ContractAddresses };
-
-export const getExistingConfig = () => {
-  try {
-    return parseJsonFile<AddressesConfig>(ADDRESS_FILE);
-  } catch (error) {
-    console.warn(error);
-  }
-
-  return undefined;
-};
 
 export const writeConfigToDisk = (config: NetworkConfig) => {
   fs.writeFileSync(ADDRESS_FILE, JSON.stringify(config));
@@ -43,7 +33,7 @@ export const updateConfig = (
   }
 
   return {
-    ...getExistingConfig(),
+    ...getExistingConfig(ADDRESS_FILE),
     [`${network}.${chainId}`]: contractAddresses,
   };
 };

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -71,6 +71,9 @@ export const deployContracts = async (
   const customSmartWalletDeployVerifierF = await ethers.getContractFactory(
     'CustomSmartWalletDeployVerifier'
   );
+  const nativeHolderSmartWalletF = await ethers.getContractFactory(
+    'NativeHolderSmartWallet'
+  );
 
   const versionRegistryFactory = await ethers.getContractFactory(
     'VersionRegistry'
@@ -103,7 +106,18 @@ export const deployContracts = async (
       customSmartWalletFactoryAddress
     );
   const { address: customRelayVerifierAddress } = await relayVerifierF.deploy(
-    smartWalletFactoryAddress
+    customSmartWalletFactoryAddress
+  );
+
+  const { address: nativeHolderSmartWalletAddress } =
+    await nativeHolderSmartWalletF.deploy();
+  const { address: nativeHolderSmartWalletFactoryAddress } =
+    await smartWalletFactoryF.deploy(nativeHolderSmartWalletAddress);
+  const { address: nativeDeployVerifierAddress } = await deployVerifierF.deploy(
+    nativeHolderSmartWalletFactoryAddress
+  );
+  const { address: nativeRelayVerifierAddress } = await relayVerifierF.deploy(
+    nativeHolderSmartWalletFactoryAddress
   );
 
   const { address: versionRegistryAddress } =
@@ -126,6 +140,10 @@ export const deployContracts = async (
     CustomSmartWalletFactory: customSmartWalletFactoryAddress,
     CustomSmartWalletDeployVerifier: customDeployVerifierAddress,
     CustomSmartWalletRelayVerifier: customRelayVerifierAddress,
+    NativeHolderSmartWallet: nativeHolderSmartWalletAddress,
+    NativeHolderSmartWalletFactory: nativeHolderSmartWalletFactoryAddress,
+    NativeHolderSmartWalletDeployVerifier: nativeDeployVerifierAddress,
+    NativeHolderSmartWalletRelayVerifier: nativeRelayVerifierAddress,
     UtilToken: utilTokenAddress,
     VersionRegistry: versionRegistryAddress,
   };

--- a/tasks/getAllowedTokens.ts
+++ b/tasks/getAllowedTokens.ts
@@ -2,7 +2,6 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { getVerifiers } from './utils';
 
 export const getAllowedTokens = async (hre: HardhatRuntimeEnvironment) => {
-
   const {
     deployVerifier,
     relayVerifier,

--- a/tasks/getAllowedTokens.ts
+++ b/tasks/getAllowedTokens.ts
@@ -1,71 +1,16 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { getExistingConfig } from './deploy';
+import { getVerifiers } from './utils';
 
 export const getAllowedTokens = async (hre: HardhatRuntimeEnvironment) => {
-  const { ethers, network } = hre;
 
-  if (!network) {
-    throw new Error('Unknown Network');
-  }
-
-  const { chainId } = network.config;
-
-  if (!chainId) {
-    throw new Error('Unknown Chain Id');
-  }
-
-  const contractAddresses = getExistingConfig();
-
-  if (!contractAddresses) {
-    throw new Error('No contracts deployed');
-  }
-
-  const networkChainKey = `${network.name}.${chainId}`;
-  const contractAddressesDeployed = contractAddresses[networkChainKey];
-  if (!contractAddressesDeployed) {
-    throw new Error(`Contracts not deployed for chain ID ${chainId}`);
-  }
-
-  const deployVerifierAddress = contractAddressesDeployed.DeployVerifier;
-  const relayVerifierAddress = contractAddressesDeployed.RelayVerifier;
-  const customDeployVerifierAddress =
-    contractAddressesDeployed.CustomSmartWalletDeployVerifier;
-  const customRelayVerifierAddress =
-    contractAddressesDeployed.CustomSmartWalletRelayVerifier;
-
-  if (!deployVerifierAddress) {
-    throw new Error('Could not obtain deploy verifier address');
-  }
-
-  if (!relayVerifierAddress) {
-    throw new Error('Could not obtain relay verifier address');
-  }
-
-  if (!customDeployVerifierAddress) {
-    throw new Error('Could not obtain custom deploy verifier address');
-  }
-
-  if (!customRelayVerifierAddress) {
-    throw new Error('Could not obtain custom deploy verifier address');
-  }
-
-  const deployVerifier = await ethers.getContractAt(
-    'DeployVerifier',
-    deployVerifierAddress
-  );
-  const relayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    relayVerifierAddress
-  );
-  const customDeployVerifier = await ethers.getContractAt(
-    'CustomSmartWalletDeployVerifier',
-    customDeployVerifierAddress
-  );
-
-  const customRelayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    customRelayVerifierAddress
-  );
+  const {
+    deployVerifier,
+    relayVerifier,
+    customDeployVerifier,
+    customRelayVerifier,
+    nativeHolderDeployVerifier,
+    nativeHolderRelayVerifier,
+  } = await getVerifiers(hre);
 
   const verifierMap: Map<
     string,
@@ -75,6 +20,8 @@ export const getAllowedTokens = async (hre: HardhatRuntimeEnvironment) => {
   verifierMap.set('relayVerifier', relayVerifier);
   verifierMap.set('customDeployVerifier', customDeployVerifier);
   verifierMap.set('customRelayVerifier', customRelayVerifier);
+  verifierMap.set('nativeHolderDeployVerifier', nativeHolderDeployVerifier);
+  verifierMap.set('nativeHolderRelayVerifier', nativeHolderRelayVerifier);
 
   for (const [key, verifier] of verifierMap) {
     try {

--- a/tasks/removeTokens.ts
+++ b/tasks/removeTokens.ts
@@ -1,6 +1,6 @@
 import { ContractTransaction } from 'ethers';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { getExistingConfig } from './deploy';
+import { getVerifiers } from './utils';
 
 export const removeTokens = async (
   taskArgs: { tokenlist: string },
@@ -8,96 +8,14 @@ export const removeTokens = async (
 ) => {
   const tokenAddresses = taskArgs.tokenlist.split(',');
 
-  const { ethers, network } = hre;
-
-  if (!network) {
-    throw new Error('Unknown Network');
-  }
-
-  const { chainId } = network.config;
-
-  if (!chainId) {
-    throw new Error('Unknown Chain Id');
-  }
-
-  const contractAddresses = getExistingConfig();
-
-  if (!contractAddresses) {
-    throw new Error('No contracts deployed');
-  }
-
-  const networkChainKey = `${network.name}.${chainId}`;
-  const contractAddressesDeployed = contractAddresses[networkChainKey];
-
-  if (!contractAddressesDeployed) {
-    throw new Error(`Contracts not deployed for chain ID ${chainId}`);
-  }
-
-  const deployVerifierAddress = contractAddressesDeployed.DeployVerifier;
-  const relayVerifierAddress = contractAddressesDeployed.RelayVerifier;
-  const customDeployVerifierAddress =
-    contractAddressesDeployed.CustomSmartWalletDeployVerifier;
-  const customRelayVerifierAddress =
-    contractAddressesDeployed.CustomSmartWalletRelayVerifier;
-  const nativeDeployVerifierAddress =
-    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
-  const nativeRelayVerifierAddress =
-    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
-
-  // TODO: This need to be refactored
-  if (!deployVerifierAddress) {
-    throw new Error('Could not obtain deploy verifier address');
-  }
-
-  if (!relayVerifierAddress) {
-    throw new Error('Could not obtain relay verifier address');
-  }
-
-  if (!customDeployVerifierAddress) {
-    throw new Error('Could not obtain custom deploy verifier address');
-  }
-
-  if (!customRelayVerifierAddress) {
-    throw new Error('Could not obtain custom deploy verifier address');
-  }
-
-  if (!nativeDeployVerifierAddress) {
-    throw new Error(
-      'Could not obtain deploy verifier address for the NativeHolderSmartWallet'
-    );
-  }
-
-  if (!nativeRelayVerifierAddress) {
-    throw new Error(
-      'Could not obtain relay verifier address for the NativeHolderSmartWallet'
-    );
-  }
-
-  const deployVerifier = await ethers.getContractAt(
-    'DeployVerifier',
-    deployVerifierAddress
-  );
-  const relayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    relayVerifierAddress
-  );
-  const customDeployVerifier = await ethers.getContractAt(
-    'CustomSmartWalletDeployVerifier',
-    customDeployVerifierAddress
-  );
-  const customRelayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    customRelayVerifierAddress
-  );
-
-  const nativeHolderDeployVerifier = await ethers.getContractAt(
-    'DeployVerifier',
-    nativeDeployVerifierAddress
-  );
-  const nativeHolderRelayVerifier = await ethers.getContractAt(
-    'RelayVerifier',
-    nativeRelayVerifierAddress
-  );
+  const {
+    deployVerifier,
+    relayVerifier,
+    customDeployVerifier,
+    customRelayVerifier,
+    nativeHolderDeployVerifier,
+    nativeHolderRelayVerifier,
+  } = await getVerifiers(hre);
 
   const verifierMap: Map<
     string,

--- a/tasks/removeTokens.ts
+++ b/tasks/removeTokens.ts
@@ -39,7 +39,12 @@ export const removeTokens = async (
     contractAddressesDeployed.CustomSmartWalletDeployVerifier;
   const customRelayVerifierAddress =
     contractAddressesDeployed.CustomSmartWalletRelayVerifier;
+  const nativeDeployVerifierAddress =
+    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
+  const nativeRelayVerifierAddress =
+    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
 
+  // TODO: This need to be refactored
   if (!deployVerifierAddress) {
     throw new Error('Could not obtain deploy verifier address');
   }
@@ -54,6 +59,18 @@ export const removeTokens = async (
 
   if (!customRelayVerifierAddress) {
     throw new Error('Could not obtain custom deploy verifier address');
+  }
+
+  if (!nativeDeployVerifierAddress) {
+    throw new Error(
+      'Could not obtain deploy verifier address for the NativeHolderSmartWallet'
+    );
+  }
+
+  if (!nativeRelayVerifierAddress) {
+    throw new Error(
+      'Could not obtain relay verifier address for the NativeHolderSmartWallet'
+    );
   }
 
   const deployVerifier = await ethers.getContractAt(
@@ -73,6 +90,15 @@ export const removeTokens = async (
     customRelayVerifierAddress
   );
 
+  const nativeHolderDeployVerifier = await ethers.getContractAt(
+    'DeployVerifier',
+    nativeDeployVerifierAddress
+  );
+  const nativeHolderRelayVerifier = await ethers.getContractAt(
+    'RelayVerifier',
+    nativeRelayVerifierAddress
+  );
+
   const verifierMap: Map<
     string,
     {
@@ -88,6 +114,8 @@ export const removeTokens = async (
   verifierMap.set('relayVerifier', relayVerifier);
   verifierMap.set('customDeployVerifier', customDeployVerifier);
   verifierMap.set('customRelayVerifier', customRelayVerifier);
+  verifierMap.set('nativeHolderDeployVerifier', nativeHolderDeployVerifier);
+  verifierMap.set('nativeHolderRelayVerifier', nativeHolderRelayVerifier);
 
   for (const tokenAddress of tokenAddresses) {
     for (const [key, verifier] of verifierMap) {

--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { AddressesConfig } from './deploy';
 
-
 // TODO: we may convert this function to return a promise
 export const parseJsonFile = <T>(filePath: string) => {
   if (fs.existsSync(filePath)) {
@@ -13,9 +12,11 @@ export const parseJsonFile = <T>(filePath: string) => {
 
 const ADDRESS_FILE = process.env['ADDRESS_FILE'] || 'contract-addresses.json';
 
-export const getExistingConfig = (addressFile?: string): AddressesConfig | undefined => {
+export const getExistingConfig = (
+  addressFile?: string
+): AddressesConfig | undefined => {
   try {
-    return parseJsonFile<AddressesConfig>(addressFile||ADDRESS_FILE);
+    return parseJsonFile<AddressesConfig>(addressFile || ADDRESS_FILE);
   } catch (error) {
     console.warn(error);
   }

--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -11,10 +11,11 @@ export const parseJsonFile = <T>(filePath: string) => {
   throw new Error(`The file ${filePath} doesn't exist`);
 };
 
+const ADDRESS_FILE = process.env['ADDRESS_FILE'] || 'contract-addresses.json';
 
-export const getExistingConfig = (addressFile: string): AddressesConfig | undefined => {
+export const getExistingConfig = (addressFile?: string): AddressesConfig | undefined => {
   try {
-    return parseJsonFile<AddressesConfig>(addressFile);
+    return parseJsonFile<AddressesConfig>(addressFile||ADDRESS_FILE);
   } catch (error) {
     console.warn(error);
   }

--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -1,4 +1,7 @@
 import fs from 'fs';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { AddressesConfig } from './deploy';
+
 
 // TODO: we may convert this function to return a promise
 export const parseJsonFile = <T>(filePath: string) => {
@@ -7,3 +10,115 @@ export const parseJsonFile = <T>(filePath: string) => {
   }
   throw new Error(`The file ${filePath} doesn't exist`);
 };
+
+
+export const getExistingConfig = (addressFile: string): AddressesConfig | undefined => {
+  try {
+    return parseJsonFile<AddressesConfig>(addressFile);
+  } catch (error) {
+    console.warn(error);
+  }
+
+  return undefined;
+};
+
+export async function getVerifiers(hre: HardhatRuntimeEnvironment) {
+  const { ethers, network } = hre;
+
+  if (!network) {
+    throw new Error('Unknown Network');
+  }
+
+  const { chainId } = network.config;
+
+  if (!chainId) {
+    throw new Error('Unknown Chain Id');
+  }
+
+  const contractAddresses = getExistingConfig();
+
+  if (!contractAddresses) {
+    throw new Error('No contracts deployed');
+  }
+
+  const networkChainKey = `${network.name}.${chainId}`;
+  const contractAddressesDeployed = contractAddresses[networkChainKey];
+  if (!contractAddressesDeployed) {
+    throw new Error(`Contracts not deployed for chain ID ${chainId}`);
+  }
+
+  const deployVerifierAddress = contractAddressesDeployed.DeployVerifier;
+  const relayVerifierAddress = contractAddressesDeployed.RelayVerifier;
+  const customDeployVerifierAddress =
+    contractAddressesDeployed.CustomSmartWalletDeployVerifier;
+  const customRelayVerifierAddress =
+    contractAddressesDeployed.CustomSmartWalletRelayVerifier;
+  const nativeDeployVerifierAddress =
+    contractAddressesDeployed.NativeHolderSmartWalletDeployVerifier;
+  const nativeRelayVerifierAddress =
+    contractAddressesDeployed.NativeHolderSmartWalletRelayVerifier;
+
+  if (!deployVerifierAddress) {
+    throw new Error('Could not obtain deploy verifier address');
+  }
+
+  if (!relayVerifierAddress) {
+    throw new Error('Could not obtain relay verifier address');
+  }
+
+  if (!customDeployVerifierAddress) {
+    throw new Error('Could not obtain custom deploy verifier address');
+  }
+
+  if (!customRelayVerifierAddress) {
+    throw new Error('Could not obtain custom deploy verifier address');
+  }
+
+  if (!nativeDeployVerifierAddress) {
+    throw new Error(
+      'Could not obtain native deploy verifier address for the NativeHolderSmartWallet'
+    );
+  }
+
+  if (!nativeRelayVerifierAddress) {
+    throw new Error(
+      'Could not obtain native relay verifier address for the NativeHolderSmartWallet'
+    );
+  }
+
+  const deployVerifier = await ethers.getContractAt(
+    'DeployVerifier',
+    deployVerifierAddress
+  );
+  const relayVerifier = await ethers.getContractAt(
+    'RelayVerifier',
+    relayVerifierAddress
+  );
+  const customDeployVerifier = await ethers.getContractAt(
+    'CustomSmartWalletDeployVerifier',
+    customDeployVerifierAddress
+  );
+
+  const customRelayVerifier = await ethers.getContractAt(
+    'RelayVerifier',
+    customRelayVerifierAddress
+  );
+
+  const nativeHolderDeployVerifier = await ethers.getContractAt(
+    'DeployVerifier',
+    nativeDeployVerifierAddress
+  );
+  const nativeHolderRelayVerifier = await ethers.getContractAt(
+    'RelayVerifier',
+    nativeRelayVerifierAddress
+  );
+
+  return {
+    deployVerifier,
+    relayVerifier,
+    customDeployVerifier,
+    customRelayVerifier,
+    nativeHolderDeployVerifier,
+    nativeHolderRelayVerifier,
+  };
+}

--- a/test/smartwallet/nativeHolderSmartWallet.test.ts
+++ b/test/smartwallet/nativeHolderSmartWallet.test.ts
@@ -3,500 +3,389 @@ import { BaseProvider } from '@ethersproject/providers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BigNumber, ethers, Wallet } from 'ethers';
+import {
+  BaseContract,
+  BigNumber,
+  ContractTransaction,
+  ethers,
+  PayableOverrides,
+  Wallet,
+} from 'ethers';
 import { ethers as hardhat } from 'hardhat';
 import {
   ERC20,
   NativeHolderSmartWallet,
   NativeHolderSmartWallet__factory,
 } from '../../typechain-types';
+import { PromiseOrValue } from '../../typechain-types/common';
+import {
+  getLocalEip712Signature,
+  TypedRequestData,
+} from '../utils/EIP712Utils';
+import {
+  buildDomainSeparator,
+  createRequest,
+  getSuffixData,
+  HARDHAT_CHAIN_ID,
+} from './utils';
 
 chai.use(smock.matchers);
 chai.use(chaiAsPromised);
 
-describe.only('SmartWallet contract', function () {
-  describe('Function directExecuteWithValue() mocked', function () {
-    let mockSmartWallet: MockContract<NativeHolderSmartWallet>;
-    let provider: BaseProvider;
-    let owner: Wallet;
-    let fakeToken: FakeContract<ERC20>;
-    let fundedAccount: SignerWithAddress;
+const recipientABI = [
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'message',
+        type: 'string',
+      },
+    ],
+    name: 'emitMessage',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+];
+interface TestRecipient extends BaseContract {
+  functions: {
+    emitMessage(
+      message: PromiseOrValue<string>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+  };
+}
 
-    beforeEach(async function () {
-      [, fundedAccount] = (await hardhat.getSigners()) as [
-        SignerWithAddress,
-        SignerWithAddress,
-        SignerWithAddress
-      ];
+const INITIAL_SW_BALANCE = hardhat.utils.parseEther('5');
+const TWO_ETHERS = ethers.utils.parseEther('2');
 
-      const mockSmartWalletFactory =
-        await smock.mock<NativeHolderSmartWallet__factory>(
-          'NativeHolderSmartWallet'
-        );
+describe('NativeHolderSmartWallet contract', function () {
+  let smartWallet: MockContract<NativeHolderSmartWallet>;
+  let provider: BaseProvider;
+  let owner: Wallet;
+  let fakeToken: FakeContract<ERC20>;
+  let fundedAccount: SignerWithAddress;
+  let relayHub: SignerWithAddress;
+  let worker: SignerWithAddress;
+  let privateKey: Buffer;
+  let recipientContract: FakeContract<TestRecipient>;
+  let encodedFunctionData: string;
 
-      provider = hardhat.provider;
-      owner = hardhat.Wallet.createRandom().connect(provider);
+  beforeEach(async function () {
+    [relayHub, fundedAccount, worker] = (await hardhat.getSigners()) as [
+      SignerWithAddress,
+      SignerWithAddress,
+      SignerWithAddress
+    ];
 
-      //Fund the owner
-      await fundedAccount.sendTransaction({
-        to: owner.address,
-        value: hardhat.utils.parseEther('1'),
+    const mockSmartWalletFactory =
+      await smock.mock<NativeHolderSmartWallet__factory>(
+        'NativeHolderSmartWallet'
+      );
+
+    provider = hardhat.provider;
+    owner = hardhat.Wallet.createRandom().connect(provider);
+
+    //Fund the owner
+    await fundedAccount.sendTransaction({
+      to: owner.address,
+      value: hardhat.utils.parseEther('1'),
+    });
+    smartWallet = await mockSmartWalletFactory.connect(owner).deploy();
+    const domainSeparator = buildDomainSeparator(smartWallet.address);
+    await smartWallet.setVariable('domainSeparator', domainSeparator);
+
+    fakeToken = await smock.fake('ERC20');
+    fakeToken.transfer.returns(true);
+
+    privateKey = Buffer.from(owner.privateKey.substring(2, 66), 'hex');
+
+    recipientContract = await smock.fake<TestRecipient>(recipientABI);
+    encodedFunctionData = recipientContract.interface.encodeFunctionData(
+      'emitMessage',
+      ['hello']
+    );
+
+    await fundedAccount.sendTransaction({
+      to: smartWallet.address,
+      value: INITIAL_SW_BALANCE,
+    });
+  });
+
+  async function expectBalanceToBeRight(
+    execution: () => Promise<void>,
+    recipientAddress: string,
+    expectedRecipientBalance: BigNumber,
+    expectedSwBalance: BigNumber
+  ) {
+    await execution();
+
+    const recipientBalanceAfterExecution = await provider.getBalance(
+      recipientAddress
+    );
+    const swBalanceAfterExecution = await provider.getBalance(
+      smartWallet.address
+    );
+
+    expect(expectedRecipientBalance.toString()).to.be.equal(
+      recipientBalanceAfterExecution.toString()
+    );
+    expect(expectedSwBalance.toString()).to.be.equal(
+      swBalanceAfterExecution.toString()
+    );
+  }
+
+  async function expectBalanceAfterSuccessExecution(
+    recipientAddress: string,
+    value: BigNumber,
+    execution: () => Promise<void>
+  ) {
+    const recipientBalancePriorExecution = await provider.getBalance(
+      recipientAddress
+    );
+    const swBalancePriorExecution = await provider.getBalance(
+      smartWallet.address
+    );
+
+    const valueBN = BigNumber.from(value);
+
+    const expectedRecipientBalance = BigNumber.from(
+      recipientBalancePriorExecution
+    ).add(valueBN);
+    const expectedSwBalance = BigNumber.from(swBalancePriorExecution).sub(
+      valueBN
+    );
+    await expectBalanceToBeRight(
+      execution,
+      recipientAddress,
+      expectedRecipientBalance,
+      expectedSwBalance
+    );
+  }
+
+  describe('execute', function () {
+    type PrepareRequestParams = {
+      data: string;
+      value?: string;
+    };
+
+    function prepareRequest({
+      data = '0x',
+      value = TWO_ETHERS.toString(),
+    }: PrepareRequestParams) {
+      const relayRequest = createRequest(
+        {
+          relayHub: relayHub.address,
+          from: owner.address,
+          to: recipientContract.address,
+          tokenAmount: '10',
+          tokenGas: '40000',
+          tokenContract: fakeToken.address,
+          data,
+          value
+        },
+        {
+          callForwarder: smartWallet.address,
+        }
+      );
+
+      const typedRequestData = new TypedRequestData(
+        HARDHAT_CHAIN_ID,
+        smartWallet.address,
+        relayRequest
+      );
+      const signature = getLocalEip712Signature(typedRequestData, privateKey);
+      const suffixData = getSuffixData(typedRequestData);
+
+      return {
+        relayRequest,
+        suffixData,
+        signature,
+      };
+    }
+
+    it('Should transfer native currency without executing transactions', async function () {
+      const { relayRequest, suffixData, signature } = prepareRequest({
+        data: '0x',
+        value: TWO_ETHERS.toString(),
       });
-      mockSmartWallet = await mockSmartWalletFactory.connect(owner).deploy();
 
-      fakeToken = await smock.fake('ERC20');
-      fakeToken.transfer.returns(true);
+      const execution = async () => {
+        await expect(
+          smartWallet
+            .connect(relayHub)
+            .execute(
+              suffixData,
+              relayRequest.request,
+              worker.address,
+              signature
+            )
+        ).not.to.be.rejected;
+
+        expect(fakeToken.transfer, 'Token.transfer() was not called').to.be
+          .called;
+      };
+
+      await expectBalanceAfterSuccessExecution(
+        recipientContract.address,
+        TWO_ETHERS,
+        execution
+      );
     });
 
-    it('Should transfer native currency without executing a transaction', async function () {
-      const recipient = Wallet.createRandom();
-      await fundedAccount.sendTransaction({
-        to: mockSmartWallet.address,
-        value: hardhat.utils.parseEther('5'),
+    it('Should transfer native currency and execute transaction', async function () {
+      const { relayRequest, suffixData, signature } = prepareRequest({
+        data: encodedFunctionData,
       });
 
+      const execution = async () => {
+        await expect(
+          smartWallet
+            .connect(relayHub)
+            .execute(
+              suffixData,
+              relayRequest.request,
+              worker.address,
+              signature
+            )
+        ).not.to.be.rejected;
+
+        expect(fakeToken.transfer, 'Token.transfer() was not called').to.be
+          .called;
+        expect(recipientContract.emitMessage, 'Recipient method was not called')
+          .to.be.called;
+      };
+
+      await expectBalanceAfterSuccessExecution(
+        recipientContract.address,
+        TWO_ETHERS,
+        execution
+      );
+    });
+
+    it('Should fail if the smart wallet cannot pay native currency', async function () {
+      // we try to transfer a value higher than the SW balance
+      const valueToTransfer = INITIAL_SW_BALANCE.add(
+        ethers.utils.parseEther('1')
+      ).toString();
+      const { relayRequest, suffixData, signature } = prepareRequest({
+        data: encodedFunctionData,
+        value: valueToTransfer.toString(),
+      });
+
+      const execution = async function () {
+        // Use the static call to check the returned values
+        const tx = await smartWallet
+          .connect(relayHub)
+          .callStatic.execute(
+            suffixData,
+            relayRequest.request,
+            worker.address,
+            signature
+          );
+        expect(tx.success, 'Success is true').to.be.false;
+
+        await expect(
+          smartWallet
+            .connect(relayHub)
+            .execute(
+              suffixData,
+              relayRequest.request,
+              worker.address,
+              signature
+            ),
+          'Execute transaction rejected'
+        ).not.to.be.rejected;
+      };
+
       const recipientBalancePriorExecution = await provider.getBalance(
-        recipient.address
+        recipientContract.address
       );
       const swBalancePriorExecution = await provider.getBalance(
-        mockSmartWallet.address
+        smartWallet.address
       );
 
+      await expectBalanceToBeRight(execution, recipientContract.address, recipientBalancePriorExecution, swBalancePriorExecution);
+    });
+  });
+
+  describe('Function directExecuteWithValue()', function () {
+
+    it('Should transfer native currency without executing transactions', async function () {
+      const execution = async () => {
+        await expect(
+          smartWallet.directExecuteWithValue(
+            recipientContract.address,
+            TWO_ETHERS,
+            '0x00'
+          ),
+          'Execution failed'
+        ).not.to.be.rejected;
+      };
+      await expectBalanceAfterSuccessExecution(
+        recipientContract.address,
+        TWO_ETHERS,
+        execution
+      );
+    });
+
+    it('Should transfer native currency and execute transactions', async function () {
       const value = ethers.utils.parseEther('2');
-
-      await expect(
-        mockSmartWallet.directExecuteWithValue(
-          recipient.address,
-          value,
-          '0x00'
-        ),
-        'Execution failed'
-      ).not.to.be.rejected;
-
-      const recipientBalanceAfterExecution = await provider.getBalance(
-        recipient.address
+      const execution = async () => {
+        await expect(
+          smartWallet.directExecuteWithValue(
+            recipientContract.address,
+            value,
+            encodedFunctionData
+          ),
+          'Execution failed'
+        ).not.to.be.rejected;
+      };
+      await expectBalanceAfterSuccessExecution(
+        recipientContract.address,
+        value,
+        execution
       );
-      const swBalanceAfterExecution = await provider.getBalance(
-        mockSmartWallet.address
+    });
+
+    it('Should fail if the smart wallet cannot pay native currency', async function () {
+      const recipientBalancePriorExecution = await provider.getBalance(
+        recipientContract.address
+      );
+      const swBalancePriorExecution = await provider.getBalance(
+        smartWallet.address
       );
 
-      const valueBN = BigNumber.from(value);
-
-      const expectedRecipientBalance = BigNumber.from(
-        recipientBalancePriorExecution
-      ).add(valueBN);
-      const expectedSwBalance = BigNumber.from(swBalancePriorExecution).sub(
-        valueBN
+      const valueToTransfer = INITIAL_SW_BALANCE.add(
+        ethers.utils.parseEther('1')
       );
 
-      expect(expectedRecipientBalance.toString()).to.be.equal(
-        recipientBalanceAfterExecution.toString()
-      );
-      expect(expectedSwBalance.toString()).to.be.equal(
-        swBalanceAfterExecution.toString()
-      );
+      const execution = async () => {
+        // Use the static call to check the returned values
+        const tx = await smartWallet.callStatic.directExecuteWithValue(
+          recipientContract.address,
+          valueToTransfer,
+          encodedFunctionData
+        );
+        expect(tx.success, 'Success is true').to.be.false;
+  
+        await expect(
+          smartWallet.directExecuteWithValue(
+            recipientContract.address,
+            valueToTransfer,
+            encodedFunctionData
+          ),
+          'Execution failed'
+        ).not.to.be.rejected;
+      }
+
+      await expectBalanceToBeRight(execution, recipientContract.address, recipientBalancePriorExecution, swBalancePriorExecution)
     });
   });
 });
-
-/* import { use, expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import { BN } from 'ethereumjs-util';
-import { toWei } from 'web3-utils';
-import {
-    NativeHolderSmartWalletInstance,
-    SmartWalletFactoryInstance,
-    TestRecipientInstance
-} from '../../types/truffle-contracts';
-import {
-    createRequest,
-    createSmartWallet,
-    createSmartWalletFactory,
-    getGaslessAccount,
-    getTestingEnvironment,
-    signRequest
-} from '../utils';
-
-use(chaiAsPromised);
-
-const NativeSmartWallet = artifacts.require('NativeHolderSmartWallet');
-const TestRecipient = artifacts.require('TestRecipient');
-
-contract('NativeHolderSmartWallet', ([worker, sender, fundedAccount]) => {
-    const senderPrivateKey: Buffer = Buffer.from(
-        '0c06818f82e04c564290b32ab86b25676731fc34e9a546108bf109194c8e3aae',
-        'hex'
-    );
-    describe('execute', () => {
-        let nativeSw: NativeHolderSmartWalletInstance;
-        let factory: SmartWalletFactoryInstance;
-        let chainId: number;
-        let recipientContract: TestRecipientInstance;
-
-        beforeEach(async () => {
-            chainId = (await getTestingEnvironment()).chainId;
-            const nativeSwTemplate = await NativeSmartWallet.new();
-            factory = await createSmartWalletFactory(nativeSwTemplate);
-            nativeSw = await createSmartWallet<NativeHolderSmartWalletInstance>(
-                {
-                    relayHub: worker,
-                    ownerEOA: sender,
-                    factory,
-                    privKey: senderPrivateKey,
-                    chainId,
-                    smartWalletContractName: 'NativeHolderSmartWallet'
-                }
-            );
-            recipientContract = await TestRecipient.new();
-        });
-
-        it('Should transfer native currency without executing a transaction', async () => {
-            const initialNonce = await nativeSw.nonce();
-
-            await web3.eth.sendTransaction({
-                from: fundedAccount,
-                to: nativeSw.address,
-                value: toWei('5', 'ether')
-            });
-
-            const recipient = await getGaslessAccount();
-
-            const recipientBalancePriorExecution = await web3.eth.getBalance(
-                recipient.address
-            );
-            const swBalancePriorExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const value = toWei('2', 'ether');
-
-            const relayRequest = createRequest(
-                {
-                    data: '0x00',
-                    to: recipient.address,
-                    nonce: initialNonce.toString(),
-                    relayHub: worker,
-                    from: sender,
-                    value
-                },
-                {
-                    callForwarder: nativeSw.address
-                }
-            );
-
-            const { signature, suffixData } = signRequest(
-                senderPrivateKey,
-                relayRequest,
-                chainId
-            );
-
-            await nativeSw.execute(
-                suffixData,
-                relayRequest.request,
-                worker,
-                signature,
-                { from: worker }
-            );
-
-            const recipientBalanceAfterExecution = await web3.eth.getBalance(
-                recipient.address
-            );
-            const swBalanceAfterExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const valueBN = new BN(value);
-
-            const expectedRecipientBalance = new BN(
-                recipientBalancePriorExecution
-            ).add(valueBN);
-            const expectedSwBalance = new BN(swBalancePriorExecution).sub(
-                valueBN
-            );
-
-            expect(expectedRecipientBalance.toString()).to.be.equal(
-                recipientBalanceAfterExecution.toString()
-            );
-            expect(expectedSwBalance.toString()).to.be.equal(
-                swBalanceAfterExecution.toString()
-            );
-        });
-
-        it('Should transfer native currency and execute transaction', async () => {
-            const initialNonce = await nativeSw.nonce();
-
-            await web3.eth.sendTransaction({
-                from: fundedAccount,
-                to: nativeSw.address,
-                value: toWei('5', 'ether')
-            });
-
-            const recipientBalancePriorExecution = await web3.eth.getBalance(
-                recipientContract.address
-            );
-            const swBalancePriorExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const value = toWei('2', 'ether');
-
-            const encodedData = recipientContract.contract.methods
-                .emitMessage('hello')
-                .encodeABI();
-
-            const relayRequest = createRequest(
-                {
-                    data: encodedData,
-                    to: recipientContract.address,
-                    nonce: initialNonce.toString(),
-                    relayHub: worker,
-                    from: sender,
-                    value
-                },
-                {
-                    callForwarder: nativeSw.address
-                }
-            );
-
-            const { signature, suffixData } = signRequest(
-                senderPrivateKey,
-                relayRequest,
-                chainId
-            );
-
-            await nativeSw.execute(
-                suffixData,
-                relayRequest.request,
-                worker,
-                signature,
-                { from: worker }
-            );
-
-            // @ts-ignore
-            const logs = await recipientContract.getPastEvents(
-                'SampleRecipientEmitted'
-            );
-            expect(logs.length).to.be.equal(1, 'TestRecipient should emit');
-
-            const recipientBalanceAfterExecution = await web3.eth.getBalance(
-                recipientContract.address
-            );
-            const swBalanceAfterExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const valueBN = new BN(value);
-
-            const expectedRecipientBalance = new BN(
-                recipientBalancePriorExecution
-            ).add(valueBN);
-            const expectedSwBalance = new BN(swBalancePriorExecution).sub(
-                valueBN
-            );
-
-            expect(expectedRecipientBalance.toString()).to.be.equal(
-                recipientBalanceAfterExecution.toString()
-            );
-            expect(expectedSwBalance.toString()).to.be.equal(
-                swBalanceAfterExecution.toString()
-            );
-        });
-
-        it('Should fail if smart wallet cannot pay native currency', async () => {
-            const initialNonce = await nativeSw.nonce();
-
-            const value = toWei('2', 'ether');
-
-            const encodedData = recipientContract.contract.methods
-                .emitMessage('hello')
-                .encodeABI();
-
-            const relayRequest = createRequest(
-                {
-                    data: encodedData,
-                    to: recipientContract.address,
-                    nonce: initialNonce.toString(),
-                    relayHub: worker,
-                    from: sender,
-                    value
-                },
-                {
-                    callForwarder: nativeSw.address
-                }
-            );
-
-            const { signature, suffixData } = signRequest(
-                senderPrivateKey,
-                relayRequest,
-                chainId
-            );
-
-            await nativeSw.execute(
-                suffixData,
-                relayRequest.request,
-                worker,
-                signature,
-                { from: worker }
-            );
-
-            // @ts-ignore
-            const logs = await recipientContract.getPastEvents(
-                'SampleRecipientEmitted'
-            );
-            expect(logs.length).to.be.equal(0, 'TestRecipient should not emit');
-        });
-    });
-
-    describe('directExecuteWithValue', () => {
-        let nativeSw: NativeHolderSmartWalletInstance;
-        let factory: SmartWalletFactoryInstance;
-        let chainId: number;
-
-        let recipientContract: TestRecipientInstance;
-
-        beforeEach(async () => {
-            chainId = (await getTestingEnvironment()).chainId;
-            const nativeSwTemplate = await NativeSmartWallet.new();
-            factory = await createSmartWalletFactory(nativeSwTemplate);
-            nativeSw = await createSmartWallet<NativeHolderSmartWalletInstance>(
-                {
-                    relayHub: worker,
-                    ownerEOA: sender,
-                    factory,
-                    privKey: senderPrivateKey,
-                    chainId,
-                    smartWalletContractName: 'NativeHolderSmartWallet'
-                }
-            );
-            recipientContract = await TestRecipient.new();
-        });
-
-        it('Should transfer native currency without executing a transaction', async () => {
-            await web3.eth.sendTransaction({
-                from: fundedAccount,
-                to: nativeSw.address,
-                value: toWei('5', 'ether')
-            });
-
-            const recipient = await getGaslessAccount();
-
-            const recipientBalancePriorExecution = await web3.eth.getBalance(
-                recipient.address
-            );
-            const swBalancePriorExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const value = toWei('2', 'ether');
-
-            await nativeSw.directExecuteWithValue(
-                recipient.address,
-                value,
-                '0x00',
-                { from: sender }
-            );
-
-            const recipientBalanceAfterExecution = await web3.eth.getBalance(
-                recipient.address
-            );
-            const swBalanceAfterExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const valueBN = new BN(value);
-
-            const expectedRecipientBalance = new BN(
-                recipientBalancePriorExecution
-            ).add(valueBN);
-            const expectedSwBalance = new BN(swBalancePriorExecution).sub(
-                valueBN
-            );
-
-            expect(expectedRecipientBalance.toString()).to.be.equal(
-                recipientBalanceAfterExecution.toString()
-            );
-            expect(expectedSwBalance.toString()).to.be.equal(
-                swBalanceAfterExecution.toString()
-            );
-        });
-
-        it('Should transfer native currency and execute transaction', async () => {
-            await web3.eth.sendTransaction({
-                from: fundedAccount,
-                to: nativeSw.address,
-                value: toWei('5', 'ether')
-            });
-
-            const recipientBalancePriorExecution = await web3.eth.getBalance(
-                recipientContract.address
-            );
-            const swBalancePriorExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const value = toWei('2', 'ether');
-
-            const encodedData = recipientContract.contract.methods
-                .emitMessage('hello')
-                .encodeABI();
-
-            await nativeSw.directExecuteWithValue(
-                recipientContract.address,
-                value,
-                encodedData,
-                { from: sender }
-            );
-
-            // @ts-ignore
-            const logs = await recipientContract.getPastEvents(
-                'SampleRecipientEmitted'
-            );
-            expect(logs.length).to.be.equal(1, 'TestRecipient should emit');
-
-            const recipientBalanceAfterExecution = await web3.eth.getBalance(
-                recipientContract.address
-            );
-            const swBalanceAfterExecution = await web3.eth.getBalance(
-                nativeSw.address
-            );
-
-            const valueBN = new BN(value);
-
-            const expectedRecipientBalance = new BN(
-                recipientBalancePriorExecution
-            ).add(valueBN);
-            const expectedSwBalance = new BN(swBalancePriorExecution).sub(
-                valueBN
-            );
-
-            expect(expectedRecipientBalance.toString()).to.be.equal(
-                recipientBalanceAfterExecution.toString()
-            );
-            expect(expectedSwBalance.toString()).to.be.equal(
-                swBalanceAfterExecution.toString()
-            );
-        });
-
-        it('Should fail if smart wallet cannot pay native currency', async () => {
-            const value = toWei('2', 'ether');
-
-            const encodedData = recipientContract.contract.methods
-                .emitMessage('hello')
-                .encodeABI();
-
-            await nativeSw.directExecuteWithValue(
-                recipientContract.address,
-                value,
-                encodedData,
-                { from: sender }
-            );
-
-            // @ts-ignore
-            const logs = await recipientContract.getPastEvents(
-                'SampleRecipientEmitted'
-            );
-            expect(logs.length).to.be.equal(0, 'TestRecipient should not emit');
-        });
-    });
-});
- */

--- a/test/smartwallet/nativeHolderSmartWallet.test.ts
+++ b/test/smartwallet/nativeHolderSmartWallet.test.ts
@@ -188,7 +188,7 @@ describe('NativeHolderSmartWallet contract', function () {
           tokenGas: '40000',
           tokenContract: fakeToken.address,
           data,
-          value
+          value,
         },
         {
           callForwarder: smartWallet.address,
@@ -311,12 +311,16 @@ describe('NativeHolderSmartWallet contract', function () {
         smartWallet.address
       );
 
-      await expectBalanceToBeRight(execution, recipientContract.address, recipientBalancePriorExecution, swBalancePriorExecution);
+      await expectBalanceToBeRight(
+        execution,
+        recipientContract.address,
+        recipientBalancePriorExecution,
+        swBalancePriorExecution
+      );
     });
   });
 
   describe('Function directExecuteWithValue()', function () {
-
     it('Should transfer native currency without executing transactions', async function () {
       const execution = async () => {
         await expect(
@@ -374,7 +378,7 @@ describe('NativeHolderSmartWallet contract', function () {
           encodedFunctionData
         );
         expect(tx.success, 'Success is true').to.be.false;
-  
+
         await expect(
           smartWallet.directExecuteWithValue(
             recipientContract.address,
@@ -383,9 +387,14 @@ describe('NativeHolderSmartWallet contract', function () {
           ),
           'Execution failed'
         ).not.to.be.rejected;
-      }
+      };
 
-      await expectBalanceToBeRight(execution, recipientContract.address, recipientBalancePriorExecution, swBalancePriorExecution)
+      await expectBalanceToBeRight(
+        execution,
+        recipientContract.address,
+        recipientBalancePriorExecution,
+        swBalancePriorExecution
+      );
     });
   });
 });

--- a/test/smartwallet/nativeHolderSmartWallet.test.ts
+++ b/test/smartwallet/nativeHolderSmartWallet.test.ts
@@ -320,11 +320,11 @@ describe('NativeHolderSmartWallet contract', function () {
     });
   });
 
-  describe('Function directExecuteWithValue()', function () {
+  describe('Function directExecute(address to,uint256 value,bytes calldata data)', function () {
     it('Should transfer native currency without executing transactions', async function () {
       const execution = async () => {
         await expect(
-          smartWallet.directExecuteWithValue(
+          smartWallet['directExecute(address,uint256,bytes)'](
             recipientContract.address,
             TWO_ETHERS,
             '0x00'
@@ -343,7 +343,7 @@ describe('NativeHolderSmartWallet contract', function () {
       const value = ethers.utils.parseEther('2');
       const execution = async () => {
         await expect(
-          smartWallet.directExecuteWithValue(
+          smartWallet['directExecute(address,uint256,bytes)'](
             recipientContract.address,
             value,
             encodedFunctionData
@@ -372,15 +372,13 @@ describe('NativeHolderSmartWallet contract', function () {
 
       const execution = async () => {
         // Use the static call to check the returned values
-        const tx = await smartWallet.callStatic.directExecuteWithValue(
-          recipientContract.address,
-          valueToTransfer,
-          encodedFunctionData
-        );
+        const tx = await smartWallet.callStatic[
+          'directExecute(address,uint256,bytes)'
+        ](recipientContract.address, valueToTransfer, encodedFunctionData);
         expect(tx.success, 'Success is true').to.be.false;
 
         await expect(
-          smartWallet.directExecuteWithValue(
+          smartWallet['directExecute(address,uint256,bytes)'](
             recipientContract.address,
             valueToTransfer,
             encodedFunctionData

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -6,18 +6,29 @@ import chaiAsPromised from 'chai-as-promised';
 import { Wallet } from 'ethers';
 import { ethers as hardhat } from 'hardhat';
 import {
-  ERC20, SmartWallet,
-  SmartWalletFactory, SmartWallet__factory
+  ERC20,
+  SmartWallet,
+  SmartWalletFactory,
+  SmartWallet__factory,
 } from 'typechain-types';
 import {
   EnvelopingTypes,
-  IForwarder
+  IForwarder,
 } from 'typechain-types/contracts/RelayHub';
 import { createValidPersonalSignSignature } from '../utils/createValidPersonalSignSignature';
 import {
-  getLocalEip712DeploySignature, getLocalEip712Signature, TypedDeployRequestData, TypedRequestData
+  getLocalEip712DeploySignature,
+  getLocalEip712Signature,
+  TypedDeployRequestData,
+  TypedRequestData,
 } from '../utils/EIP712Utils';
-import { buildDomainSeparator, createRequest, getSuffixData, HARDHAT_CHAIN_ID } from './utils';
+import {
+  buildDomainSeparator,
+  createRequest,
+  getSuffixData,
+  HARDHAT_CHAIN_ID,
+  RelayData,
+} from './utils';
 
 chai.use(smock.matchers);
 chai.use(chaiAsPromised);
@@ -72,7 +83,6 @@ describe('SmartWallet contract', function () {
       },
     };
   }
-
 
   async function createSmartWalletFactory(owner: Wallet) {
     const smartWalletTemplateFactory = await hardhat.getContractFactory(

--- a/test/smartwallet/smartWallet.test.ts
+++ b/test/smartwallet/smartWallet.test.ts
@@ -1,41 +1,29 @@
-import { ethers as hardhat } from 'hardhat';
+import { FakeContract, MockContract, smock } from '@defi-wonderland/smock';
+import { BaseProvider } from '@ethersproject/providers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import chai, { expect } from 'chai';
-import { FakeContract, smock } from '@defi-wonderland/smock';
 import chaiAsPromised from 'chai-as-promised';
-import { TypedDataUtils } from '@metamask/eth-sig-util';
-import {
-  getLocalEip712Signature,
-  TypedRequestData,
-  TypedDeployRequestData,
-  getLocalEip712DeploySignature,
-} from '../utils/EIP712Utils';
-import { SignTypedDataVersion } from '@metamask/eth-sig-util';
 import { Wallet } from 'ethers';
+import { ethers as hardhat } from 'hardhat';
 import {
-  SmartWallet,
-  SmartWalletFactory,
-  ERC20,
-  SmartWallet__factory,
+  ERC20, SmartWallet,
+  SmartWalletFactory, SmartWallet__factory
 } from 'typechain-types';
-import { BaseProvider } from '@ethersproject/providers';
 import {
   EnvelopingTypes,
-  IForwarder,
+  IForwarder
 } from 'typechain-types/contracts/RelayHub';
-import { MockContract } from '@defi-wonderland/smock';
 import { createValidPersonalSignSignature } from '../utils/createValidPersonalSignSignature';
+import {
+  getLocalEip712DeploySignature, getLocalEip712Signature, TypedDeployRequestData, TypedRequestData
+} from '../utils/EIP712Utils';
+import { buildDomainSeparator, createRequest, getSuffixData, HARDHAT_CHAIN_ID } from './utils';
 
 chai.use(smock.matchers);
 chai.use(chaiAsPromised);
 
 const ZERO_ADDRESS = hardhat.constants.AddressZero;
-const ONE_FIELD_IN_BYTES = 32;
-const HARDHAT_CHAIN_ID = 31337;
 
-type ForwardRequest = IForwarder.ForwardRequestStruct;
-type RelayData = EnvelopingTypes.RelayDataStruct;
-type RelayRequest = EnvelopingTypes.RelayRequestStruct;
 type DeployRequest = EnvelopingTypes.DeployRequestStruct;
 type DeployRequestInternal = IForwarder.DeployRequestStruct;
 
@@ -45,44 +33,6 @@ describe('SmartWallet contract', function () {
   let owner: Wallet;
   let relayHub: SignerWithAddress;
   let fakeToken: FakeContract<ERC20>;
-
-  function createRequest(
-    request: Partial<ForwardRequest>,
-    relayData?: Partial<RelayData>
-  ): RelayRequest {
-    const baseRequest: RelayRequest = {
-      request: {
-        relayHub: ZERO_ADDRESS,
-        from: ZERO_ADDRESS,
-        to: ZERO_ADDRESS,
-        tokenContract: ZERO_ADDRESS,
-        value: '0',
-        gas: '10000',
-        nonce: '0',
-        tokenAmount: '0',
-        tokenGas: '50000',
-        validUntilTime: '0',
-        data: '0x',
-      },
-      relayData: {
-        gasPrice: '1',
-        feesReceiver: ZERO_ADDRESS,
-        callForwarder: ZERO_ADDRESS,
-        callVerifier: ZERO_ADDRESS,
-      },
-    };
-
-    return {
-      request: {
-        ...baseRequest.request,
-        ...request,
-      },
-      relayData: {
-        ...baseRequest.relayData,
-        ...relayData,
-      },
-    };
-  }
 
   function createDeployRequest(
     request: Partial<DeployRequestInternal>,
@@ -123,31 +73,6 @@ describe('SmartWallet contract', function () {
     };
   }
 
-  function buildDomainSeparator(address: string) {
-    const domainSeparator = {
-      name: 'RSK Enveloping Transaction',
-      version: '2',
-      chainId: HARDHAT_CHAIN_ID,
-      verifyingContract: address,
-    };
-
-    return hardhat.utils._TypedDataEncoder.hashDomain(domainSeparator);
-  }
-
-  function getSuffixData(typedRequestData: TypedRequestData): string {
-    const encoded = TypedDataUtils.encodeData(
-      typedRequestData.primaryType,
-      typedRequestData.message,
-      typedRequestData.types,
-      SignTypedDataVersion.V4
-    );
-
-    const messageSize = Object.keys(typedRequestData.message).length;
-
-    return (
-      '0x' + encoded.slice(messageSize * ONE_FIELD_IN_BYTES).toString('hex')
-    );
-  }
 
   async function createSmartWalletFactory(owner: Wallet) {
     const smartWalletTemplateFactory = await hardhat.getContractFactory(

--- a/test/smartwallet/utils.ts
+++ b/test/smartwallet/utils.ts
@@ -1,0 +1,75 @@
+import { TypedDataUtils, SignTypedDataVersion } from '@metamask/eth-sig-util';
+import { ethers } from 'hardhat';
+import { IForwarder } from '../../typechain-types';
+import { EnvelopingTypes } from '../../typechain-types/contracts/RelayHub';
+import { TypedRequestData } from '../utils/EIP712Utils';
+
+const ZERO_ADDRESS = ethers.constants.AddressZero;
+export const HARDHAT_CHAIN_ID = 31337;
+const ONE_FIELD_IN_BYTES = 32;
+
+export type ForwardRequest = IForwarder.ForwardRequestStruct;
+export type RelayRequest = EnvelopingTypes.RelayRequestStruct;
+export type RelayData = EnvelopingTypes.RelayDataStruct;
+
+export function createRequest(
+  request: Partial<ForwardRequest>,
+  relayData?: Partial<RelayData>
+): RelayRequest {
+  const baseRequest: RelayRequest = {
+    request: {
+      relayHub: ZERO_ADDRESS,
+      from: ZERO_ADDRESS,
+      to: ZERO_ADDRESS,
+      tokenContract: ZERO_ADDRESS,
+      value: '0',
+      gas: '10000',
+      nonce: '0',
+      tokenAmount: '0',
+      tokenGas: '50000',
+      validUntilTime: '0',
+      data: '0x',
+    },
+    relayData: {
+      gasPrice: '1',
+      feesReceiver: ZERO_ADDRESS,
+      callForwarder: ZERO_ADDRESS,
+      callVerifier: ZERO_ADDRESS,
+    },
+  };
+
+  return {
+    request: {
+      ...baseRequest.request,
+      ...request,
+    },
+    relayData: {
+      ...baseRequest.relayData,
+      ...relayData,
+    },
+  };
+}
+
+export function getSuffixData(typedRequestData: TypedRequestData): string {
+  const encoded = TypedDataUtils.encodeData(
+    typedRequestData.primaryType,
+    typedRequestData.message,
+    typedRequestData.types,
+    SignTypedDataVersion.V4
+  );
+
+  const messageSize = Object.keys(typedRequestData.message).length;
+
+  return '0x' + encoded.slice(messageSize * ONE_FIELD_IN_BYTES).toString('hex');
+}
+
+export function buildDomainSeparator(address: string) {
+  const domainSeparator = {
+    name: 'RSK Enveloping Transaction',
+    version: '2',
+    chainId: HARDHAT_CHAIN_ID,
+    verifyingContract: address,
+  };
+
+  return ethers.utils._TypedDataEncoder.hashDomain(domainSeparator);
+}

--- a/test/tasks/allowTokens.test.ts
+++ b/test/tasks/allowTokens.test.ts
@@ -6,6 +6,7 @@ import * as hre from 'hardhat';
 import { ethers } from 'hardhat';
 import sinon from 'sinon';
 import { allowTokens } from '../../tasks/allowTokens';
+import { stubReadFileSync } from './utils';
 
 use(chaiAsPromised);
 
@@ -15,32 +16,9 @@ describe('Allow Tokens Script', function () {
       tokenlist: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
     };
 
-    const contractAddresses = {
-      Penalizer: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      RelayHub: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      SmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      SmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      DeployVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      RelayVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletDeployVerifier:
-        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletRelayVerifier:
-        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      VersionRegistry: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      UtilToken: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-    };
-
-    const chainContractAddresses = {
-      'hardhat.33': contractAddresses,
-    };
-
     beforeEach(function () {
       sinon.stub(fs, 'existsSync').returns(true);
-      sinon
-        .stub(fs, 'readFileSync')
-        .returns(JSON.stringify(chainContractAddresses));
+        stubReadFileSync()
       hre.network.config.chainId = 33;
     });
 

--- a/test/tasks/allowTokens.test.ts
+++ b/test/tasks/allowTokens.test.ts
@@ -18,7 +18,7 @@ describe('Allow Tokens Script', function () {
 
     beforeEach(function () {
       sinon.stub(fs, 'existsSync').returns(true);
-        stubReadFileSync()
+      stubReadFileSync();
       hre.network.config.chainId = 33;
     });
 

--- a/test/tasks/deploy.test.ts
+++ b/test/tasks/deploy.test.ts
@@ -37,6 +37,10 @@ describe('Deploy Script', function () {
         'CustomSmartWalletFactory',
         'CustomSmartWalletDeployVerifier',
         'CustomSmartWalletRelayVerifier',
+        'NativeHolderSmartWallet',
+        'NativeHolderSmartWalletFactory',
+        'NativeHolderSmartWalletDeployVerifier',
+        'NativeHolderSmartWalletRelayVerifier',
         'VersionRegistry',
         'UtilToken'
       );

--- a/test/tasks/getAllowedTokens.test.ts
+++ b/test/tasks/getAllowedTokens.test.ts
@@ -6,37 +6,16 @@ import * as hre from 'hardhat';
 import { ethers } from 'hardhat';
 import sinon from 'sinon';
 import { getAllowedTokens } from '../../tasks/getAllowedTokens';
+import { stubReadFileSync } from './utils';
 
 use(chaiAsPromised);
 
 describe('Get Allowed Tokens Script', function () {
   describe('getAllowedTokens', function () {
-    const contractAddresses = {
-      Penalizer: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      RelayHub: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      SmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      SmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      DeployVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      RelayVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletDeployVerifier:
-        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletRelayVerifier:
-        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      VersionRegistry: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      UtilToken: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-    };
-
-    const chainContractAddresses = {
-      'hardhat.33': contractAddresses,
-    };
 
     beforeEach(function () {
       sinon.stub(fs, 'existsSync').returns(true);
-      sinon
-        .stub(fs, 'readFileSync')
-        .returns(JSON.stringify(chainContractAddresses));
+      stubReadFileSync()
       hre.network.config.chainId = 33;
     });
 

--- a/test/tasks/getAllowedTokens.test.ts
+++ b/test/tasks/getAllowedTokens.test.ts
@@ -12,10 +12,9 @@ use(chaiAsPromised);
 
 describe('Get Allowed Tokens Script', function () {
   describe('getAllowedTokens', function () {
-
     beforeEach(function () {
       sinon.stub(fs, 'existsSync').returns(true);
-      stubReadFileSync()
+      stubReadFileSync();
       hre.network.config.chainId = 33;
     });
 

--- a/test/tasks/removeTokens.test.ts
+++ b/test/tasks/removeTokens.test.ts
@@ -6,6 +6,7 @@ import * as hre from 'hardhat';
 import { ethers } from 'hardhat';
 import sinon from 'sinon';
 import { removeTokens } from '../../tasks/removeTokens';
+import { stubReadFileSync } from './utils';
 
 use(chaiAsPromised);
 
@@ -15,32 +16,9 @@ describe('Remove Tokens Script', function () {
       tokenlist: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
     };
 
-    const contractAddresses = {
-      Penalizer: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      RelayHub: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      SmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      SmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      DeployVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      RelayVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletDeployVerifier:
-        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      CustomSmartWalletRelayVerifier:
-        '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      VersionRegistry: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-      UtilToken: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
-    };
-
-    const chainContractAddresses = {
-      'hardhat.33': contractAddresses,
-    };
-
     beforeEach(function () {
       sinon.stub(fs, 'existsSync').returns(true);
-      sinon
-        .stub(fs, 'readFileSync')
-        .returns(JSON.stringify(chainContractAddresses));
+      stubReadFileSync();
       hre.network.config.chainId = 33;
     });
 

--- a/test/tasks/utils.ts
+++ b/test/tasks/utils.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import sinon from 'sinon';
+
+const defaultContractAddresses = {
+  Penalizer: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  RelayHub: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  SmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  SmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  DeployVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  RelayVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  CustomSmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  CustomSmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  CustomSmartWalletDeployVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  CustomSmartWalletRelayVerifier: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  NativeHolderSmartWallet: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  NativeHolderSmartWalletFactory: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  NativeHolderSmartWalletDeployVerifier:
+    '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  NativeHolderSmartWalletRelayVerifier:
+    '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  VersionRegistry: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+  UtilToken: '0x145845fd06c85B7EA1AA2d030E1a747B3d8d15D7',
+};
+
+const defaultChainContractAddresses = {
+  'hardhat.33': defaultContractAddresses,
+};
+
+export const stubReadFileSync = (
+  chainContractAddresses = defaultChainContractAddresses
+) => {
+  sinon
+    .stub(fs, 'readFileSync')
+    .returns(JSON.stringify(chainContractAddresses));
+};

--- a/utils/scripts/types.ts
+++ b/utils/scripts/types.ts
@@ -16,7 +16,7 @@ const factoryList = {
     : never ;
   
   export type ContractAddresses = {
-    [key in (ContractName | 'CustomSmartWalletRelayVerifier')]: string | undefined;
+    [key in (ContractName | 'CustomSmartWalletRelayVerifier' | 'NativeHolderSmartWalletFactory' | 'NativeHolderSmartWalletDeployVerifier' | 'NativeHolderSmartWalletRelayVerifier')]: string | undefined;
   };
   
   export type NetworkConfig = {


### PR DESCRIPTION
## What

- Migrate the NativeHolderSmartWallet tests to ethers
- Support the NativeHolderSmartWallet in the allowTokens and removeTokens script
- Rename directExecuteWithValue to directExecute

## Why

- Tests were written with truffle/web3

