### PR TITLE
PP720: Modify withdraw script to allow it to run with just one token

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -186,19 +186,19 @@ For further info about `truffle exec`, please have a look at its [official docum
 
 ### Withdraw
 
-To call the withdraw() method available on the Collector contract, the repo provides the utility script `collector:withdraw`. It allows the user to call the `withdraw()` function from the Collector contract. It receives the following parameters:
+To withdraw (share) the funds from the Collector contract, the repository provides the utility script `collector:withdraw`. It allows the user to call either the `withdraw()` or `withdrawToken()` function from the Collector contract. It receives the following parameters:
 
-- `collector-address`: mandatory, it's the address of the collector we want to change;
-- `partner-config`: a path specifying the file that contains the partner configuration for the deployed collector;
-- `gas-limit`: optional, it's the gas limit used for the transaction. If the transaction fails, we may probably need to specify an higher value; default value is `200000`;
+- `collector-address`: Mandatory. It's the address of the collector;
+- `token-address`: Optional. It's the address of the token contract to withdraw. If provided, the function `withdrawToken()` will be called with this specific value, otherwise the function `withdraw()` will be called and the withdraw will be executed on all the allowed tokens;
+- `gas-limit`: Optional. It's the gas limit used for the transaction. Default value is `200000`;
 
 ```bash
-npx hardhat collector:withdraw --collector-address='<0xcollector_address>' --partner-config "<file_including_partners_config.json>"  --gas-limit='<gas_limit>' --network regtest
+npx hardhat collector:withdraw --collector-address '<0xcollector_address>' --token-address '<0xtoken_address>'  --gas-limit <gas_limit> --network <network-name>
 ```
 
 Example:
 ```bash
-npx hardhat collector:withdraw --collector-address "0x9b91c655AaE10E6cd0a941Aa90A6e7aa97FB02F4" --partner-config "partner-shares.json" --gas-limit "300000" --network regtest
+npx hardhat collector:withdraw --collector-address "0x0Aa058aD63E36bC2f98806f2D638353AE89C3634" --token-address "0x6f217dEd6c86A57f1211F464302e6fA544045B4f" --gas-limit 500000 --network regtest 
 ```
 
 ## Library usage

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -151,9 +151,9 @@ task('collector:withdraw', 'Withdraws funds from a collector contract')
     'collectorAddress',
     'address of the collector we want to withdraw from'
   )
-  .addParam(
-    'partnerConfig',
-    'path of the file that includes the partner shares configuration'
+  .addOptionalParam(
+    'tokenAddress',
+    'Token to withdraw. If undefined, all tokens will be withdrawn'
   )
   .addOptionalParam('gasLimit', 'gasLimit to be used for the transaction')
   .setAction(async (taskArgs: WithdrawSharesArg, hre) => {

--- a/tasks/withdraw.ts
+++ b/tasks/withdraw.ts
@@ -12,7 +12,7 @@ type MinimumErc20TokenContract = {
   balanceOf: (address: string) => Promise<BigNumber>;
 };
 
-const minimumABI = [
+const MINIMUM_ABI = [
   {
     constant: true,
     inputs: [{ name: '_owner', type: 'address' }],
@@ -21,6 +21,8 @@ const minimumABI = [
     type: 'function',
   },
 ];
+
+export const DEFAULT_TX_GAS = 200000;
 
 const printStatus = async (
   collectorAddress: string,
@@ -32,7 +34,7 @@ const printStatus = async (
     console.log(`\tToken address: ${tokenAddress}`);
 
     const tokenInstance = (await hre.ethers.getContractAt(
-      minimumABI,
+      MINIMUM_ABI,
       tokenAddress
     )) as unknown as MinimumErc20TokenContract;
 
@@ -49,8 +51,6 @@ const printStatus = async (
   }
 };
 
-const DEFAULT_TX_GAS = 200000;
-
 export const withdraw = async (
   {
     collectorAddress,
@@ -65,17 +65,23 @@ export const withdraw = async (
   );
 
   const partners = await collector.getPartners();
+  console.log('partners: ', partners);
 
-  const parsedPartners = partners.map((partnerConfig) => {
-    return partnerConfig.beneficiary;
+  const partnersAddresses = partners.map((partner) => {
+    return partner.beneficiary;
   });
 
-  const tokenAddresses = tokenAddress
+  const tokenAddressesToWithdraw = tokenAddress
     ? [tokenAddress]
     : await collector.getTokens();
 
   console.log('---Balance before---');
-  await printStatus(collectorAddress, parsedPartners, tokenAddresses, hre);
+  await printStatus(
+    collectorAddress,
+    partnersAddresses,
+    tokenAddressesToWithdraw,
+    hre
+  );
 
   try {
     tokenAddress
@@ -92,5 +98,10 @@ export const withdraw = async (
   }
 
   console.log('---Balance after---');
-  await printStatus(collectorAddress, parsedPartners, tokenAddresses, hre);
+  await printStatus(
+    collectorAddress,
+    partnersAddresses,
+    tokenAddressesToWithdraw,
+    hre
+  );
 };

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -1,53 +1,63 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, Contract, Wallet } from 'ethers';
 import * as hre from 'hardhat';
 import { ethers } from 'hardhat';
-import { withdraw } from '../../tasks/withdraw';
-import sinon, { SinonSpy, SinonStub, SinonStubbedInstance } from 'sinon';
-import * as utils from '../../tasks/utils';
 import {
-  ChangePartnerSharesArg,
-  PartnerConfig,
-} from 'tasks/changePartnerShares';
+  withdraw,
+  WithdrawSharesArg,
+  DEFAULT_TX_GAS,
+} from '../../tasks/withdraw';
+import sinon, { SinonSpy, SinonStubbedInstance } from 'sinon';
 import console from 'console';
 
 use(chaiAsPromised);
 
+const PARTNERS_CONFIG = [
+  {
+    beneficiary: '0x7986b3DF570230288501EEa3D890bd66948C9B79',
+  },
+  {
+    beneficiary: '0x0a3aA774752ec2042c46548456c094A76C7F3a79',
+  },
+];
+const FIRST_TOKEN = Wallet.createRandom().address;
+const SECOND_TOKEN = Wallet.createRandom().address;
+const ALLOWED_TOKENS = [FIRST_TOKEN, SECOND_TOKEN];
+const SPECIFIED_TX_GAS = 150000;
+
 describe('Withdraw Script', function () {
-  const mandatoryArgs: ChangePartnerSharesArg = {
+  const mandatoryArgs: WithdrawSharesArg = {
     collectorAddress: '0xc354D97642FAa06781b76Ffb6786f72cd7746C97',
-    partnerConfig: 'path/to/config/file',
   };
-  const parsedPartnerConfig: PartnerConfig = {
-    partners: [
-      {
-        beneficiary: '0x7986b3DF570230288501EEa3D890bd66948C9B79',
-        share: 50,
-      },
-      {
-        beneficiary: '0x0a3aA774752ec2042c46548456c094A76C7F3a79',
-        share: 50,
-      },
-    ],
-    collectorOwner: '0x4E28f372BCe2d0Bf1B129b6A278F582558BF08a7',
-    tokenAddress: '0x726ECC75d5D51356AA4d0a5B648790cC345985ED',
-  };
-  describe('withdraw', function () {
-    let stubbedFileParser: SinonStub;
+
+  describe('Function withdraw()', function () {
     let stubbedERC20: SinonStubbedInstance<Contract>;
     let stubbedCollector: SinonStubbedInstance<Contract>;
     let withdrawSpy: SinonSpy;
+    let withdrawTokenSpy: SinonSpy;
 
     beforeEach(function () {
-      stubbedFileParser = sinon
-        .stub(utils, 'parseJsonFile')
-        .returns(parsedPartnerConfig);
       stubbedERC20 = sinon.createStubInstance(Contract);
       stubbedERC20['balanceOf'] = () => BigNumber.from(300000000);
+
       stubbedCollector = sinon.createStubInstance(Contract);
       stubbedCollector['withdraw'] = () => undefined;
+      stubbedCollector['withdrawToken'] = () => undefined;
+      stubbedCollector['getPartners'] = () => PARTNERS_CONFIG;
+      stubbedCollector['getTokens'] = () => ALLOWED_TOKENS;
+
       withdrawSpy = sinon.spy(stubbedCollector, 'withdraw');
+      withdrawTokenSpy = sinon.spy(stubbedCollector, 'withdrawToken');
+
+      sinon
+        .stub(ethers, 'getContractAt')
+        .withArgs('Collector', sinon.match.any)
+        .resolves(stubbedCollector)
+        .withArgs(sinon.match.any, FIRST_TOKEN)
+        .resolves(stubbedERC20)
+        .withArgs(sinon.match.any, SECOND_TOKEN)
+        .resolves(stubbedERC20);
 
       console.log = () => undefined;
       console.error = () => undefined;
@@ -57,63 +67,69 @@ describe('Withdraw Script', function () {
       sinon.restore();
     });
 
-    it('should throw an error if no partners are found in config file', async function () {
-      stubbedFileParser.returns({
-        partners: [],
+    describe('When all tokens should be withdrawn', function () {
+      it('Should call withdraw() with the default tx gas', async function () {
+        await withdraw(mandatoryArgs, hre);
+
+        expect(withdrawSpy.withArgs({ gasLimit: DEFAULT_TX_GAS }).calledOnce).to
+          .be.true;
       });
 
-      await expect(withdraw(mandatoryArgs, hre)).to.be.rejectedWith(
-        `invalid partners in ${mandatoryArgs.partnerConfig}`
-      );
+      it('Should call withdraw() with specified tx gas', async function () {
+        await withdraw({ ...mandatoryArgs, gasLimit: SPECIFIED_TX_GAS }, hre);
+
+        expect(withdrawSpy.withArgs({ gasLimit: SPECIFIED_TX_GAS }).calledOnce)
+          .to.be.true;
+      });
+
+      it('Should throw error if withdrawal fails', async function () {
+        const errorMessage = 'Error on withdrawal!';
+        stubbedCollector['withdraw'] = () => {
+          throw new Error(errorMessage);
+        };
+
+        await expect(withdraw(mandatoryArgs, hre)).to.be.rejectedWith(
+          errorMessage
+        );
+      });
     });
 
-    it('should throw error if withdrawal fails', async function () {
-      const errorMessage = 'Error on withdrawal!';
-      stubbedCollector['withdraw'] = () => {
-        throw new Error(errorMessage);
-      };
+    describe('When only a token should be withdrawn', function () {
+      it('Should call withdrawToken() with default tx gas', async function () {
+        await withdraw({ ...mandatoryArgs, tokenAddress: FIRST_TOKEN }, hre);
 
-      sinon
-        .stub(ethers, 'getContractAt')
-        .onFirstCall()
-        .resolves(stubbedERC20)
-        .onSecondCall()
-        .resolves(stubbedCollector);
+        expect(
+          withdrawTokenSpy.withArgs(FIRST_TOKEN, { gasLimit: DEFAULT_TX_GAS })
+            .calledOnce
+        ).to.be.true;
+      });
 
-      await expect(withdraw(mandatoryArgs, hre)).to.be.rejectedWith(
-        errorMessage
-      );
-    });
+      it('Should call withdrawToken() with specified tx gas', async function () {
+        await withdraw(
+          {
+            ...mandatoryArgs,
+            tokenAddress: FIRST_TOKEN,
+            gasLimit: SPECIFIED_TX_GAS,
+          },
+          hre
+        );
 
-    it('should withdraw tokens from collector contract using default tx gas', async function () {
-      sinon
-        .stub(ethers, 'getContractAt')
-        .onFirstCall()
-        .resolves(stubbedERC20)
-        .onSecondCall()
-        .resolves(stubbedCollector);
+        expect(
+          withdrawTokenSpy.withArgs(FIRST_TOKEN, { gasLimit: SPECIFIED_TX_GAS })
+            .calledOnce
+        ).to.be.true;
+      });
 
-      await withdraw(mandatoryArgs, hre);
-      expect(withdrawSpy.withArgs({ gasLimit: 200000 }).calledOnce).to.be.true;
-    });
+      it('should throw error if withdrawal fails', async function () {
+        const errorMessage = 'Error on withdrawal!';
+        stubbedCollector['withdrawToken'] = () => {
+          throw new Error(errorMessage);
+        };
 
-    it('should withdraw tokens from collector contract using specified tx gas', async function () {
-      sinon
-        .stub(ethers, 'getContractAt')
-        .onFirstCall()
-        .resolves(stubbedERC20)
-        .onSecondCall()
-        .resolves(stubbedCollector);
-
-      const gasLimit = 200001;
-
-      const argsWithGasLimit = {
-        ...mandatoryArgs,
-        gasLimit,
-      };
-
-      await withdraw(argsWithGasLimit, hre);
-      expect(withdrawSpy.withArgs({ gasLimit }).calledOnce).to.be.true;
+        await expect(
+          withdraw({ ...mandatoryArgs, tokenAddress: FIRST_TOKEN }, hre)
+        ).to.be.rejectedWith(errorMessage);
+      });
     });
   });
 });


### PR DESCRIPTION
## What

- Modify withdraw script so it receives an additional optional parameter representing the token address to withdraw. If not sent, all allowed tokens will be withdrawn.

## Why

- Adapt the script to the recent Collector changes.

## Refs

- [PP-720](https://rsklabs.atlassian.net/browse/PP-720)
