### PR TITLE
fix(PP-804): do not show an error when the address file is missing

### DIFF
--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -35,9 +35,9 @@ export const updateConfig = async (
 
   const existingConfig = (await new Promise<AddressesConfig>((resolve) => {
     resolve(parseJsonFile<AddressesConfig>(ADDRESS_FILE));
-  }).catch((_) => {
-    console.log(`Previous configuration not found at: "${ADDRESS_FILE}"`);
-  })) as AddressesConfig;
+  }).catch(() =>
+    console.log(`Previous configuration not found at: "${ADDRESS_FILE}"`)
+  )) as AddressesConfig;
 
   return {
     ...existingConfig,

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -1,15 +1,16 @@
 import { HardhatEthersHelpers, HardhatRuntimeEnvironment } from 'hardhat/types';
 import fs from 'node:fs';
 import { ContractAddresses, NetworkConfig } from '../utils/scripts/types';
-import { getExistingConfig } from './utils';
+import { parseJsonFile } from './utils';
 
 const ADDRESS_FILE = process.env['ADDRESS_FILE'] || 'contract-addresses.json';
 
 export type AddressesConfig = { [key: string]: ContractAddresses };
 
+// TODO: Use the async version of fs.writeFile
 export const writeConfigToDisk = (config: NetworkConfig) => {
   fs.writeFileSync(ADDRESS_FILE, JSON.stringify(config));
-  console.log(`address file available at: ${ADDRESS_FILE}`);
+  console.log(`Address file available at: "${ADDRESS_FILE}"`);
 };
 
 export const updateConfig = (
@@ -32,8 +33,15 @@ export const updateConfig = (
     throw new Error('Unknown Chain Id');
   }
 
+  let existingConfig = {};
+  try {
+    existingConfig = parseJsonFile<AddressesConfig>(ADDRESS_FILE);
+  } catch (error) {
+    console.log(`Previous configuration not found at: "${ADDRESS_FILE}"`);
+  }
+
   return {
-    ...getExistingConfig(ADDRESS_FILE),
+    ...existingConfig,
     [`${network}.${chainId}`]: contractAddresses,
   };
 };

--- a/test/tasks/deploy.test.ts
+++ b/test/tasks/deploy.test.ts
@@ -100,28 +100,28 @@ describe('Deploy Script', function () {
       sinon.restore();
     });
 
-    it('should generate a json config file with existing config file', function () {
+    it('should generate a json config file with existing config file', async function () {
       sinon.stub(fs, 'existsSync').returns(true);
       sinon
         .stub(fs, 'readFileSync')
         .returns(JSON.stringify(chainContractAddresses));
-      updateConfig(contractAddresses, hre);
+      await updateConfig(contractAddresses, hre);
       spyWriteFileSync.calledOnceWith(
         'contract-addresses.json',
         JSON.stringify(chainContractAddresses)
       );
     });
 
-    it('should generate a json config file when config file is not present', function () {
+    it('should generate a json config file when config file is not present', async function () {
       sinon.stub(fs, 'existsSync').returns(false);
-      updateConfig(contractAddresses, hre);
+      await updateConfig(contractAddresses, hre);
       spyWriteFileSync.calledOnceWith(
         'contract-addresses.json',
         JSON.stringify(chainContractAddresses)
       );
     });
 
-    it('should throw if network is undefined', function () {
+    it('should throw if network is undefined', async function () {
       sinon.stub(fs, 'existsSync').returns(true);
       sinon
         .stub(fs, 'readFileSync')
@@ -130,12 +130,12 @@ describe('Deploy Script', function () {
       if (hre.config.networks['regtest']) {
         hre.config.networks['regtest'].chainId = 33;
       }
-      expect(() => updateConfig(contractAddresses, hre)).to.throw(
+      await expect(updateConfig(contractAddresses, hre)).to.be.rejectedWith(
         'Unknown Network'
       );
     });
 
-    it('should throw if chainId is undefined', function () {
+    it('should throw if chainId is undefined', async function () {
       sinon.stub(fs, 'existsSync').returns(true);
       sinon
         .stub(fs, 'readFileSync')
@@ -144,7 +144,7 @@ describe('Deploy Script', function () {
       if (hre.config.networks['regtest']) {
         hre.config.networks['regtest'].chainId = undefined;
       }
-      expect(() => updateConfig(contractAddresses, hre)).to.throw(
+      await expect(updateConfig(contractAddresses, hre)).to.to.be.rejectedWith(
         'Unknown Chain Id'
       );
     });


### PR DESCRIPTION
## What

- do not raise an error when the address file is missing during the contracts deployment

## Why

- the error can be misleading and the developer could think that the deployment wasn't successful
