### PR TITLE
refactor(task/withdraw): wait for transaction receipt

### DIFF
--- a/tasks/withdraw.ts
+++ b/tasks/withdraw.ts
@@ -84,9 +84,11 @@ export const withdraw = async (
   );
 
   try {
-    tokenAddress
+    const transaction = tokenAddress
       ? await collector.withdrawToken(tokenAddress, { gasLimit })
       : await collector.withdraw({ gasLimit });
+
+    await transaction.wait();
   } catch (error) {
     console.error(
       `Error withdrawing funds from collector with address ${collectorAddress}: ${

--- a/tasks/withdraw.ts
+++ b/tasks/withdraw.ts
@@ -88,6 +88,7 @@ export const withdraw = async (
       ? await collector.withdrawToken(tokenAddress, { gasLimit })
       : await collector.withdraw({ gasLimit });
 
+    console.log(`Waiting for transaction ${transaction.hash}...`);
     await transaction.wait();
   } catch (error) {
     console.error(

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -1,6 +1,6 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BigNumber, Contract, Wallet } from 'ethers';
+import { BigNumber, Contract, ContractTransaction, Wallet } from 'ethers';
 import * as hre from 'hardhat';
 import { ethers } from 'hardhat';
 import {
@@ -36,14 +36,18 @@ describe('Withdraw Script', function () {
     let stubbedCollector: SinonStubbedInstance<Contract>;
     let withdrawSpy: SinonSpy;
     let withdrawTokenSpy: SinonSpy;
+    let stubbedContractTransaction: SinonStubbedInstance<ContractTransaction>;
 
     beforeEach(function () {
+      stubbedContractTransaction = {
+        wait: sinon.stub(),
+      } as typeof stubbedContractTransaction;
       stubbedERC20 = sinon.createStubInstance(Contract);
       stubbedERC20['balanceOf'] = () => BigNumber.from(300000000);
 
       stubbedCollector = sinon.createStubInstance(Contract);
-      stubbedCollector['withdraw'] = () => undefined;
-      stubbedCollector['withdrawToken'] = () => undefined;
+      stubbedCollector['withdraw'] = () => stubbedContractTransaction;
+      stubbedCollector['withdrawToken'] = () => stubbedContractTransaction;
       stubbedCollector['getPartners'] = () => PARTNERS_CONFIG;
       stubbedCollector['getTokens'] = () => ALLOWED_TOKENS;
 


### PR DESCRIPTION
## What

- Wait for the transaction receipt while withdrawing funds from the collector.

## Why

- The previous balance was the same as the balance after the withdrawal, since we were not waiting the tx to be processed.